### PR TITLE
Fix login and register layout

### DIFF
--- a/accesibilidad-demo/src/Landing.css
+++ b/accesibilidad-demo/src/Landing.css
@@ -252,3 +252,11 @@
   color: #2563eb;
   font-weight: 500;
 }
+
+/* Center the login and register panels */
+.auth-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+}

--- a/accesibilidad-demo/src/presentation/components/Login.jsx
+++ b/accesibilidad-demo/src/presentation/components/Login.jsx
@@ -31,8 +31,8 @@ export default function Login() {
   }
 
   return (
-    <div className="dashboard-bg">
-      <div className="central-panel" style={{ maxWidth: '600px' }}>
+    <div className="dashboard-bg auth-container">
+      <div className="central-panel" style={{ maxWidth: '600px', margin: '0 auto' }}>
         <h1 className="welcome-title" id="login-title">Iniciar Sesión</h1>
         <form className="login-form" onSubmit={handleSubmit} aria-label="Iniciar sesión">
           <label htmlFor="username">Correo</label>

--- a/accesibilidad-demo/src/presentation/components/Register.jsx
+++ b/accesibilidad-demo/src/presentation/components/Register.jsx
@@ -29,9 +29,9 @@ export default function Register() {
   }
 
   return (
-    <div className="dashboard-bg">
+    <div className="dashboard-bg auth-container">
 
-      <div className="central-panel" style={{ maxWidth: '600px' }}>
+      <div className="central-panel" style={{ maxWidth: '600px', margin: '0 auto' }}>
         <h1 className="welcome-title" id="register-title">Registrarse</h1>
         <form className="login-form" onSubmit={handleSubmit} aria-label="Crear cuenta">
           <label htmlFor="reg-email">Correo</label>


### PR DESCRIPTION
## Summary
- keep login/register panels centered on screen

## Testing
- `npm test --prefix accesibilidad-demo`

------
https://chatgpt.com/codex/tasks/task_e_6858d76ba25c832ba9262b8baff29205