### PR TITLE
Add root Dockerfile for frontend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Build stage for React frontend
+FROM node:18 AS build
+WORKDIR /app/frontend
+
+# Install dependencies separately to leverage Docker cache
+COPY frontend/package.json frontend/package-lock.json* ./
+RUN npm install --force
+
+# Copy source and environment
+COPY frontend/ .
+COPY frontend/.env .env
+
+# Build the React app
+RUN npm run build
+
+# Final stage using nginx
+FROM nginx:alpine
+COPY --from=build /app/frontend/build /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -33,11 +33,15 @@ Este repositorio contiene una demostración de un panel de monitoreo ambiental c
    Escuchará en `http://localhost:4000`.
 
 ## Uso con Docker
-1. Construye y levanta ambos servicios con:
+1. Construye la imagen del frontend desde la raiz del proyecto:
    ```bash
-   docker compose up --build
+   docker build -t dashboard-frontend .
    ```
-2. El contenedor del frontend se expone en el puerto `3000` y el del backend en `4000`.
+2. Ejecuta el contenedor de la interfaz:
+   ```bash
+   docker run -p 3000:80 dashboard-frontend
+   ```
+   La aplicación quedará disponible en `http://localhost:3000`.
 
 ## Base de datos
 En la carpeta `scripts` encontrarás `supabase_schema.sql` con el script para crear todas las tablas necesarias (usuarios, ciudades, historial de consultas y condiciones climáticas). Ejecútalo en tu proyecto de Supabase antes de usar la aplicación.


### PR DESCRIPTION
## Summary
- move Dockerfile from `frontend` folder to project root
- document build and run steps using the new Dockerfile

## Testing
- `npm install --force --prefix frontend`
- `CI=true npm test --silent --runInBand --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_685a179bf4cc832bae50aa1df55600cb