### PR TITLE
Redesign login and register pages

### DIFF
--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -1,12 +1,13 @@
 import React, { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
-import "../Landing.css";
 import { useAuth } from "../AuthContext";
 import { useSupabaseStatus } from "../hooks/useSupabaseStatus";
+import styles from "./Login.module.css";
 
 export default function Login() {
-  const [user, setUser] = useState("");
+  const [email, setEmail] = useState("");
   const [pass, setPass] = useState("");
+  const [showPass, setShowPass] = useState(false);
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState("");
   const navigate = useNavigate();
@@ -18,7 +19,7 @@ export default function Login() {
     setLoading(true);
     setMessage("");
     const { error } = await supabase.auth.signInWithPassword({
-      email: user,
+      email,
       password: pass,
     });
     if (!error) {
@@ -31,27 +32,84 @@ export default function Login() {
   }
 
   return (
-    <div className="dashboard-bg auth-container">
-      <div className="central-panel" style={{ maxWidth: '600px', margin: '0 auto' }}>
-        <h1 className="welcome-title" id="login-title">Iniciar Sesión</h1>
-        <form className="login-form" onSubmit={handleSubmit} aria-label="Iniciar sesión">
-          <label htmlFor="username">Correo</label>
-          <input
-            id="username"
-            type="email"
-            value={user}
-            onChange={(e) => setUser(e.target.value)}
-            required
-          />
-          <label htmlFor="password">Contraseña</label>
-          <input
-            id="password"
-            type="password"
-            value={pass}
-            onChange={(e) => setPass(e.target.value)}
-            required
-          />
-          <button type="submit">Ingresar</button>
+    <div className={styles.container}>
+      <div className={styles.leftPanel}>
+        <div className={styles.logoCircle}>
+          <svg width="40" height="40" viewBox="0 0 24 24" fill="none">
+            <path d="M12 3v2M12 19v2M5.64 7.64l-1.41-1.41M18.36 16.36l1.41 1.41M3 12H5M19 12h2M5.64 16.36l-1.41 1.41M18.36 7.64l1.41-1.41" stroke="#4caf50" strokeWidth="2"/>
+            <circle cx="12" cy="12" r="7" stroke="#4caf50" strokeWidth="2"/>
+          </svg>
+        </div>
+        <h2 className={styles.welcome}>¡Bienvenido de vuelta!</h2>
+        <p className={styles.desc}>Continúa tu monitoreo ambiental</p>
+        <div className={styles.statsRow}>
+          <div>
+            <span className={styles.statsNumber}>2,847</span>
+            <span className={styles.statsLabel}>Usuarios</span>
+          </div>
+          <div>
+            <span className={styles.statsNumber}>15.2 Ton</span>
+            <span className={styles.statsLabel}>Datos procesados</span>
+          </div>
+          <div>
+            <span className={styles.statsNumber}>45</span>
+            <span className={styles.statsLabel}>Sensores</span>
+          </div>
+        </div>
+      </div>
+      <div className={styles.rightPanel}>
+        <h2 className={styles.loginTitle}>Iniciar Sesión</h2>
+        <p className={styles.loginDesc}>Ingresa tus credenciales</p>
+        <form onSubmit={handleSubmit} className={styles.form} aria-label="Iniciar sesión">
+          <label className={styles.label} htmlFor="login-email">Correo Electrónico *</label>
+          <div className={styles.inputIcon}>
+            <span className={styles.icon}>
+              <svg width="18" height="18" fill="none"><path d="M2 4h14v10H2z" stroke="#888" strokeWidth="1.5"/><path d="M2 4l7 6 7-6" stroke="#888" strokeWidth="1.5"/></svg>
+            </span>
+            <input
+              id="login-email"
+              className={styles.input}
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="tu.correo@ejemplo.com"
+              required
+            />
+          </div>
+          <label className={styles.label} htmlFor="login-pass">Contraseña *</label>
+          <div className={styles.inputIcon}>
+            <span className={styles.icon}>
+              <svg width="18" height="18" fill="none"><circle cx="9" cy="9" r="7" stroke="#888" strokeWidth="1.5"/><circle cx="9" cy="9" r="2" fill="#888"/></svg>
+            </span>
+            <input
+              id="login-pass"
+              className={styles.input}
+              type={showPass ? "text" : "password"}
+              value={pass}
+              onChange={(e) => setPass(e.target.value)}
+              placeholder="********"
+              required
+            />
+            <span
+              className={styles.iconEye}
+              onClick={() => setShowPass((s) => !s)}
+              style={{ cursor: "pointer" }}
+              title="Mostrar/Ocultar"
+            >
+              {showPass ? (
+                <svg width="18" height="18" fill="none"><path d="M1 9c2-4 7-7 8-7s6 3 8 7c-2 4-7 7-8 7s-6-3-8-7z" stroke="#888" strokeWidth="1.5"/><circle cx="9" cy="9" r="2" fill="#888"/></svg>
+              ) : (
+                <svg width="18" height="18" fill="none"><path d="M1 9c2-4 7-7 8-7s6 3 8 7c-2 4-7 7-8 7s-6-3-8-7z" stroke="#888" strokeWidth="1.5"/><path d="M3 3l12 12" stroke="#888" strokeWidth="1.5"/></svg>
+              )}
+            </span>
+          </div>
+          <div className={styles.optionsRow}>
+            <label className={styles.checkboxLabel}>
+              <input type="checkbox" /> Recordarme
+            </label>
+            <a href="#" className={styles.forgot}>¿Olvidaste tu contraseña?</a>
+          </div>
+          <button type="submit" className={styles.loginBtn}>Iniciar Sesión</button>
         </form>
         {loading && <div className="loader" role="status" aria-label="Cargando"></div>}
         {message && <div className="status-message">{message}</div>}
@@ -60,9 +118,11 @@ export default function Login() {
             Error de conexión con Supabase
           </div>
         )}
-        <p style={{ marginTop: '10px', textAlign: 'center' }}>
-          ¿No tienes cuenta? <Link to="/register">Regístrate</Link>
-        </p>
+        <div className={styles.registerRow}>
+          <span>¿No tienes cuenta?</span>
+          <Link to="/register" className={styles.registerLink}>Regístrate aquí</Link>
+        </div>
+        <p className={styles.terms}>Al iniciar sesión aceptas nuestros Términos y Condiciones</p>
       </div>
     </div>
   );

--- a/frontend/src/components/Login.module.css
+++ b/frontend/src/components/Login.module.css
@@ -1,0 +1,186 @@
+.container {
+  display: flex;
+  width: 900px;
+  margin: 40px auto;
+  box-shadow: 0 2px 24px #0002;
+  background: #fff;
+  border-radius: 8px;
+  overflow: hidden;
+  min-height: 530px;
+}
+
+.leftPanel {
+  background: linear-gradient(135deg, #379e47 0%, #6dd19b 100%);
+  color: #fff;
+  flex: 1;
+  padding: 48px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.logoCircle {
+  background: #fff;
+  border-radius: 50%;
+  width: 64px;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 20px;
+}
+
+.welcome {
+  font-size: 2rem;
+  font-weight: bold;
+  margin-bottom: 12px;
+  text-align: center;
+}
+
+.desc {
+  font-size: 1.1rem;
+  margin-bottom: 30px;
+  text-align: center;
+}
+
+.statsRow {
+  display: flex;
+  gap: 36px;
+  justify-content: center;
+}
+
+.statsNumber {
+  font-size: 1.3rem;
+  font-weight: bold;
+  display: block;
+  text-align: center;
+}
+
+.statsLabel {
+  font-size: 0.9rem;
+  display: block;
+  opacity: 0.85;
+  text-align: center;
+}
+
+.rightPanel {
+  flex: 1;
+  background: #fff;
+  padding: 40px 40px 24px 40px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  border-left: 1px solid #e0e0e0;
+}
+
+.loginTitle {
+  color: #228c39;
+  font-size: 1.8rem;
+  font-weight: 700;
+  margin-bottom: 5px;
+  text-align: left;
+}
+
+.loginDesc {
+  color: #555;
+  margin-bottom: 26px;
+  font-size: 1rem;
+}
+
+.form {
+  width: 100%;
+}
+
+.label {
+  display: block;
+  margin-top: 14px;
+  margin-bottom: 6px;
+  font-weight: 600;
+  color: #333;
+}
+
+.inputIcon {
+  display: flex;
+  align-items: center;
+  position: relative;
+  margin-bottom: 10px;
+}
+
+.input {
+  width: 100%;
+  padding: 10px 36px 10px 36px;
+  font-size: 1rem;
+  border-radius: 5px;
+  border: 1px solid #bcbcbc;
+  outline: none;
+  margin-left: 0;
+}
+
+.icon {
+  position: absolute;
+  left: 10px;
+}
+
+.iconEye {
+  position: absolute;
+  right: 10px;
+}
+
+.optionsRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 12px 0 20px 0;
+  font-size: 0.98rem;
+}
+
+.checkboxLabel {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.forgot {
+  color: #23aa5c;
+  text-decoration: none;
+  font-size: 0.97rem;
+}
+
+.loginBtn {
+  width: 100%;
+  background: #4caf50;
+  color: #fff;
+  border: none;
+  padding: 12px;
+  border-radius: 5px;
+  font-size: 1.15rem;
+  font-weight: bold;
+  cursor: pointer;
+  margin-top: 10px;
+  margin-bottom: 18px;
+  transition: background 0.2s;
+}
+
+.loginBtn:hover {
+  background: #379e47;
+}
+
+.registerRow {
+  text-align: center;
+  font-size: 1rem;
+  margin-bottom: 4px;
+}
+
+.registerLink {
+  color: #23aa5c;
+  margin-left: 7px;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.terms {
+  font-size: 0.78rem;
+  color: #888;
+  text-align: center;
+}

--- a/frontend/src/components/Register.jsx
+++ b/frontend/src/components/Register.jsx
@@ -1,12 +1,15 @@
 import React, { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
-import '../Landing.css';
 import { useAuth } from '../AuthContext';
 import { useSupabaseStatus } from '../hooks/useSupabaseStatus';
+import styles from './Register.module.css';
 
 export default function Register() {
   const [email, setEmail] = useState('');
   const [pass, setPass] = useState('');
+  const [first, setFirst] = useState('');
+  const [last, setLast] = useState('');
+  const [showPass, setShowPass] = useState(false);
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState('');
   const navigate = useNavigate();
@@ -19,7 +22,7 @@ export default function Register() {
     setMessage('');
     const { data, error } = await supabase.auth.signUp({ email, password: pass });
     if (!error && data.user) {
-      await supabase.from('users').insert({ id: data.user.id, email });
+      await supabase.from('users').insert({ id: data.user.id, email, first_name: first, last_name: last });
       setMessage('Registro exitoso');
       navigate('/dashboard');
     } else {
@@ -29,16 +32,93 @@ export default function Register() {
   }
 
   return (
-    <div className="dashboard-bg auth-container">
-
-      <div className="central-panel" style={{ maxWidth: '600px', margin: '0 auto' }}>
-        <h1 className="welcome-title" id="register-title">Registrarse</h1>
-        <form className="login-form" onSubmit={handleSubmit} aria-label="Crear cuenta">
-          <label htmlFor="reg-email">Correo</label>
-          <input id="reg-email" type="email" value={email} onChange={e => setEmail(e.target.value)} required />
-          <label htmlFor="reg-pass">Contraseña</label>
-          <input id="reg-pass" type="password" value={pass} onChange={e => setPass(e.target.value)} required />
-          <button type="submit">Crear cuenta</button>
+    <div className={styles.container}>
+      <div className={styles.leftPanel}>
+        <div className={styles.logoCircle}>
+          <svg width="40" height="40" viewBox="0 0 24 24" fill="none">
+            <path d="M12 3v2M12 19v2M5.64 7.64l-1.41-1.41M18.36 16.36l1.41 1.41M3 12H5M19 12h2M5.64 16.36l-1.41 1.41M18.36 7.64l1.41-1.41" stroke="#2196f3" strokeWidth="2"/>
+            <circle cx="12" cy="12" r="7" stroke="#2196f3" strokeWidth="2"/>
+          </svg>
+        </div>
+        <h2 className={styles.title}>Únete al Panel</h2>
+        <p className={styles.desc}>Forma parte de nuestra comunidad</p>
+        <ul className={styles.benefits}>
+          <li><span>✔</span> Accede a estadísticas</li>
+          <li><span>✔</span> Gestiona tus sensores</li>
+          <li><span>✔</span> Recibe alertas personalizadas</li>
+          <li><span>✔</span> Contribuye con datos ambientales</li>
+        </ul>
+      </div>
+      <div className={styles.rightPanel}>
+        <h2 className={styles.registerTitle}>Crear Cuenta</h2>
+        <p className={styles.registerDesc}>Completa tus datos para comenzar</p>
+        <form onSubmit={handleSubmit} className={styles.form} aria-label="Crear cuenta">
+          <div className={styles.doubleInput}>
+            <div>
+              <label className={styles.label}>Nombre *</label>
+              <input className={styles.input} value={first} onChange={e => setFirst(e.target.value)} placeholder="Nombre" />
+            </div>
+            <div>
+              <label className={styles.label}>Apellidos *</label>
+              <input className={styles.input} value={last} onChange={e => setLast(e.target.value)} placeholder="Apellidos" />
+            </div>
+          </div>
+          <label className={styles.label}>Correo *</label>
+          <input className={styles.input} type="email" value={email} onChange={e => setEmail(e.target.value)} placeholder="correo@ejemplo.com" required />
+          <div className={styles.doubleInput}>
+            <div>
+              <label className={styles.label}>Teléfono *</label>
+              <div className={styles.inputIcon}>
+                <span className={styles.icon}>
+                  <svg width="17" height="17" fill="none"><rect x="2" y="2" width="13" height="13" rx="3" stroke="#888" strokeWidth="1.3"/><circle cx="8.5" cy="12" r="1.2" fill="#888"/></svg>
+                </span>
+                <input className={styles.input} placeholder="+57 300 123 4567" />
+              </div>
+            </div>
+            <div>
+              <label className={styles.label}>Facultad *</label>
+              <select className={styles.input}>
+                <option>Ingeniería</option>
+                <option>Medicina</option>
+                <option>Ciencias</option>
+              </select>
+            </div>
+          </div>
+          <label className={styles.label}>Programa Académico *</label>
+          <select className={styles.input}>
+            <option>Ingeniería Ambiental</option>
+            <option>Ingeniería Civil</option>
+            <option>Biología</option>
+          </select>
+          <label className={styles.label}>Contraseña *</label>
+          <div className={styles.inputIcon}>
+            <span className={styles.icon}>
+              <svg width="18" height="18" fill="none"><circle cx="9" cy="9" r="7" stroke="#888" strokeWidth="1.5"/><circle cx="9" cy="9" r="2" fill="#888"/></svg>
+            </span>
+            <input
+              className={styles.input}
+              type={showPass ? 'text' : 'password'}
+              value={pass}
+              onChange={e => setPass(e.target.value)}
+              placeholder="********"
+              minLength={8}
+              required
+            />
+            <span
+              className={styles.iconEye}
+              onClick={() => setShowPass(s => !s)}
+              style={{ cursor: 'pointer' }}
+              title="Mostrar/Ocultar"
+            >
+              {showPass ? (
+                <svg width="18" height="18" fill="none"><path d="M1 9c2-4 7-7 8-7s6 3 8 7c-2 4-7 7-8 7s-6-3-8-7z" stroke="#888" strokeWidth="1.5"/><circle cx="9" cy="9" r="2" fill="#888"/></svg>
+              ) : (
+                <svg width="18" height="18" fill="none"><path d="M1 9c2-4 7-7 8-7s6 3 8 7c-2 4-7 7-8 7s-6-3-8-7z" stroke="#888" strokeWidth="1.5"/><path d="M3 3l12 12" stroke="#888" strokeWidth="1.5"/></svg>
+              )}
+            </span>
+          </div>
+          <small className={styles.note}>Mínimo 8 caracteres, incluye mayúsculas, minúsculas y números</small>
+          <button type="submit" className={styles.registerBtn}>Crear Cuenta</button>
         </form>
         {loading && <div className="loader" role="status" aria-label="Cargando"></div>}
         {message && <div className="status-message">{message}</div>}

--- a/frontend/src/components/Register.module.css
+++ b/frontend/src/components/Register.module.css
@@ -1,0 +1,154 @@
+.container {
+  display: flex;
+  width: 980px;
+  margin: 40px auto;
+  box-shadow: 0 2px 24px #0002;
+  background: #fff;
+  border-radius: 8px;
+  overflow: hidden;
+  min-height: 560px;
+}
+
+.leftPanel {
+  background: linear-gradient(135deg, #1e88e5 0%, #65b1fa 100%);
+  color: #fff;
+  flex: 1.15;
+  padding: 48px 28px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.logoCircle {
+  background: #fff;
+  border-radius: 50%;
+  width: 64px;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 18px;
+}
+
+.title {
+  font-size: 2rem;
+  font-weight: bold;
+  margin-bottom: 12px;
+  text-align: center;
+}
+
+.desc {
+  font-size: 1.08rem;
+  margin-bottom: 18px;
+  text-align: center;
+}
+
+.benefits {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-size: 1.04rem;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.benefits li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.rightPanel {
+  flex: 1.3;
+  background: #fff;
+  padding: 44px 42px 28px 42px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.registerTitle {
+  color: #1876d2;
+  font-size: 1.7rem;
+  font-weight: 700;
+  margin-bottom: 5px;
+}
+
+.registerDesc {
+  color: #555;
+  margin-bottom: 18px;
+  font-size: 1rem;
+}
+
+.form {
+  width: 100%;
+}
+
+.doubleInput {
+  display: flex;
+  gap: 20px;
+  margin-bottom: 0px;
+}
+
+.label {
+  display: block;
+  margin-top: 14px;
+  margin-bottom: 6px;
+  font-weight: 600;
+  color: #333;
+}
+
+.inputIcon {
+  display: flex;
+  align-items: center;
+  position: relative;
+  margin-bottom: 0;
+}
+
+.input {
+  width: 100%;
+  padding: 10px 36px 10px 36px;
+  font-size: 1rem;
+  border-radius: 5px;
+  border: 1px solid #bcbcbc;
+  outline: none;
+  margin-bottom: 8px;
+}
+
+.icon {
+  position: absolute;
+  left: 10px;
+}
+
+.iconEye {
+  position: absolute;
+  right: 10px;
+}
+
+.note {
+  font-size: 0.82rem;
+  color: #888;
+  margin-bottom: 5px;
+  margin-left: 2px;
+}
+
+.registerBtn {
+  width: 100%;
+  background: #2196f3;
+  color: #fff;
+  border: none;
+  padding: 12px;
+  border-radius: 5px;
+  font-size: 1.12rem;
+  font-weight: bold;
+  cursor: pointer;
+  margin-top: 18px;
+  margin-bottom: 10px;
+  transition: background 0.2s;
+}
+
+.registerBtn:hover {
+  background: #1565c0;
+}


### PR DESCRIPTION
## Summary
- restyle authentication pages with split-panel design
- implement login and register forms using new components and CSS modules

## Testing
- `CI=true npm test --silent --runInBand --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_685a2f789d98832ba9a83ad1e78090d1