### PR TITLE
Improve login and register styling

### DIFF
--- a/frontend/src/Auth.css
+++ b/frontend/src/Auth.css
@@ -1,0 +1,243 @@
+/* Login page styles */
+.login-container {
+  display: flex;
+  width: 900px;
+  margin: 40px auto;
+  box-shadow: 0 2px 24px #0002;
+  background: #fff;
+  border-radius: 8px;
+  overflow: hidden;
+  min-height: 530px;
+}
+
+.login-leftPanel {
+  background: linear-gradient(135deg, #379e47 0%, #6dd19b 100%);
+  color: #fff;
+  flex: 1;
+  padding: 48px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.login-rightPanel {
+  flex: 1;
+  background: #fff;
+  padding: 40px 40px 24px 40px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  border-left: 1px solid #e0e0e0;
+}
+
+.logoCircle {
+  background: #fff;
+  border-radius: 50%;
+  width: 64px;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 20px;
+}
+
+.welcome {
+  font-size: 2rem;
+  font-weight: bold;
+  margin-bottom: 12px;
+  text-align: center;
+}
+
+.desc {
+  font-size: 1.1rem;
+  margin-bottom: 30px;
+  text-align: center;
+}
+
+.loginTitle {
+  color: #228c39;
+  font-size: 1.8rem;
+  font-weight: 700;
+  margin-bottom: 5px;
+  text-align: left;
+}
+
+.loginDesc {
+  color: #555;
+  margin-bottom: 26px;
+  font-size: 1rem;
+}
+
+.form {
+  width: 100%;
+}
+
+.label {
+  display: block;
+  margin-top: 14px;
+  margin-bottom: 6px;
+  font-weight: 600;
+  color: #333;
+}
+
+.inputIcon {
+  display: flex;
+  align-items: center;
+  position: relative;
+  margin-bottom: 10px;
+}
+
+.input {
+  width: 100%;
+  padding: 10px 36px;
+  font-size: 1rem;
+  border-radius: 5px;
+  border: 1px solid #bcbcbc;
+  outline: none;
+}
+
+.icon {
+  position: absolute;
+  left: 10px;
+}
+
+.iconEye {
+  position: absolute;
+  right: 10px;
+}
+
+.optionsRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 12px 0 20px 0;
+  font-size: 0.98rem;
+}
+
+.checkboxLabel {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.forgot {
+  color: #23aa5c;
+  text-decoration: none;
+  font-size: 0.97rem;
+}
+
+.loginBtn {
+  width: 100%;
+  background: #4caf50;
+  color: #fff;
+  border: none;
+  padding: 12px;
+  border-radius: 5px;
+  font-size: 1.15rem;
+  font-weight: bold;
+  cursor: pointer;
+  margin-top: 10px;
+  margin-bottom: 18px;
+  transition: background 0.2s;
+}
+
+.loginBtn:hover {
+  background: #379e47;
+}
+
+.registerRow {
+  text-align: center;
+  font-size: 1rem;
+  margin-bottom: 4px;
+}
+
+.registerLink {
+  color: #23aa5c;
+  margin-left: 7px;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.terms {
+  font-size: 0.78rem;
+  color: #888;
+  text-align: center;
+}
+
+/* Register page styles */
+.register-container {
+  display: flex;
+  width: 980px;
+  margin: 40px auto;
+  box-shadow: 0 2px 24px #0002;
+  background: #fff;
+  border-radius: 8px;
+  overflow: hidden;
+  min-height: 560px;
+}
+
+.register-leftPanel {
+  background: linear-gradient(135deg, #1e88e5 0%, #65b1fa 100%);
+  color: #fff;
+  flex: 1.15;
+  padding: 48px 28px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.register-rightPanel {
+  flex: 1.3;
+  background: #fff;
+  padding: 44px 42px 28px 42px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.registerTitle {
+  color: #1876d2;
+  font-size: 1.7rem;
+  font-weight: 700;
+  margin-bottom: 5px;
+}
+
+.registerDesc {
+  color: #555;
+  margin-bottom: 18px;
+  font-size: 1rem;
+}
+
+.doubleInput {
+  display: flex;
+  gap: 20px;
+  margin-bottom: 0;
+}
+
+.note {
+  font-size: 0.82rem;
+  color: #888;
+  margin-bottom: 5px;
+  margin-left: 2px;
+}
+
+.registerBtn {
+  width: 100%;
+  background: #2196f3;
+  color: #fff;
+  border: none;
+  padding: 12px;
+  border-radius: 5px;
+  font-size: 1.12rem;
+  font-weight: bold;
+  cursor: pointer;
+  margin-top: 18px;
+  margin-bottom: 10px;
+  transition: background 0.2s;
+}
+
+.registerBtn:hover {
+  background: #1565c0;
+}

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
-import "../Landing.css";
+import "../Auth.css";
+import logo from "../logo.svg";
 import { useAuth } from "../AuthContext";
 import { useSupabaseStatus } from "../hooks/useSupabaseStatus";
 
@@ -31,27 +32,41 @@ export default function Login() {
   }
 
   return (
-    <div className="dashboard-bg auth-container">
-      <div className="central-panel" style={{ maxWidth: '600px', margin: '0 auto' }}>
-        <h1 className="welcome-title" id="login-title">Iniciar Sesión</h1>
-        <form className="login-form" onSubmit={handleSubmit} aria-label="Iniciar sesión">
-          <label htmlFor="username">Correo</label>
-          <input
-            id="username"
-            type="email"
-            value={user}
-            onChange={(e) => setUser(e.target.value)}
-            required
-          />
-          <label htmlFor="password">Contraseña</label>
-          <input
-            id="password"
-            type="password"
-            value={pass}
-            onChange={(e) => setPass(e.target.value)}
-            required
-          />
-          <button type="submit">Ingresar</button>
+    <div className="login-container">
+      <div className="login-leftPanel">
+        <div className="logoCircle">
+          <img src={logo} alt="logo" width="40" />
+        </div>
+        <h2 className="welcome">Bienvenido</h2>
+        <p className="desc">Ingresa tus credenciales para continuar</p>
+      </div>
+      <div className="login-rightPanel">
+        <h2 className="loginTitle">Iniciar Sesión</h2>
+        <p className="loginDesc">Introduce tu correo y contraseña</p>
+        <form className="form" onSubmit={handleSubmit} aria-label="Iniciar sesión">
+          <label className="label" htmlFor="username">Correo</label>
+          <div className="inputIcon">
+            <input
+              className="input"
+              id="username"
+              type="email"
+              value={user}
+              onChange={(e) => setUser(e.target.value)}
+              required
+            />
+          </div>
+          <label className="label" htmlFor="password">Contraseña</label>
+          <div className="inputIcon">
+            <input
+              className="input"
+              id="password"
+              type="password"
+              value={pass}
+              onChange={(e) => setPass(e.target.value)}
+              required
+            />
+          </div>
+          <button className="loginBtn" type="submit">Ingresar</button>
         </form>
         {loading && <div className="loader" role="status" aria-label="Cargando"></div>}
         {message && <div className="status-message">{message}</div>}
@@ -60,8 +75,9 @@ export default function Login() {
             Error de conexión con Supabase
           </div>
         )}
-        <p style={{ marginTop: '10px', textAlign: 'center' }}>
-          ¿No tienes cuenta? <Link to="/register">Regístrate</Link>
+        <p className="registerRow">
+          ¿No tienes cuenta?
+          <Link className="registerLink" to="/register">Regístrate</Link>
         </p>
       </div>
     </div>

--- a/frontend/src/components/Register.jsx
+++ b/frontend/src/components/Register.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
-import '../Landing.css';
+import '../Auth.css';
+import logo from '../logo.svg';
 import { useAuth } from '../AuthContext';
 import { useSupabaseStatus } from '../hooks/useSupabaseStatus';
 
@@ -29,16 +30,41 @@ export default function Register() {
   }
 
   return (
-    <div className="dashboard-bg auth-container">
-
-      <div className="central-panel" style={{ maxWidth: '600px', margin: '0 auto' }}>
-        <h1 className="welcome-title" id="register-title">Registrarse</h1>
-        <form className="login-form" onSubmit={handleSubmit} aria-label="Crear cuenta">
-          <label htmlFor="reg-email">Correo</label>
-          <input id="reg-email" type="email" value={email} onChange={e => setEmail(e.target.value)} required />
-          <label htmlFor="reg-pass">Contraseña</label>
-          <input id="reg-pass" type="password" value={pass} onChange={e => setPass(e.target.value)} required />
-          <button type="submit">Crear cuenta</button>
+    <div className="register-container">
+      <div className="register-leftPanel">
+        <div className="logoCircle">
+          <img src={logo} alt="logo" width="40" />
+        </div>
+        <h2 className="title">Crea tu cuenta</h2>
+        <p className="desc">Regístrate para acceder al panel</p>
+      </div>
+      <div className="register-rightPanel">
+        <h2 className="registerTitle">Registrarse</h2>
+        <p className="registerDesc">Introduce tus datos</p>
+        <form className="form" onSubmit={handleSubmit} aria-label="Crear cuenta">
+          <label className="label" htmlFor="reg-email">Correo</label>
+          <div className="inputIcon">
+            <input
+              className="input"
+              id="reg-email"
+              type="email"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              required
+            />
+          </div>
+          <label className="label" htmlFor="reg-pass">Contraseña</label>
+          <div className="inputIcon">
+            <input
+              className="input"
+              id="reg-pass"
+              type="password"
+              value={pass}
+              onChange={e => setPass(e.target.value)}
+              required
+            />
+          </div>
+          <button className="registerBtn" type="submit">Crear cuenta</button>
         </form>
         {loading && <div className="loader" role="status" aria-label="Cargando"></div>}
         {message && <div className="status-message">{message}</div>}
@@ -47,8 +73,9 @@ export default function Register() {
             Error de conexión con Supabase
           </div>
         )}
-        <p style={{ marginTop: '10px', textAlign: 'center' }}>
-          ¿Ya tienes cuenta? <Link to="/login">Ingresa</Link>
+        <p className="registerRow">
+          ¿Ya tienes cuenta?
+          <Link className="registerLink" to="/login">Ingresa</Link>
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- create new `Auth.css` with green/blue themes
- restyle Login and Register components

## Testing
- `npm test --prefix frontend --silent`


------
https://chatgpt.com/codex/tasks/task_e_685a3264e36c832bbad0cd006ee6ae52