### PR TITLE
Add profile and admin pages

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,6 +6,8 @@ import Welcome from "./components/Welcome";
 import Placeholder from "./components/Placeholder";
 import Login from "./components/Login";
 import Register from "./components/Register";
+import Profile from "./components/Profile";
+import AdminPanel from "./components/AdminPanel";
 import { AuthProvider } from "./AuthContext";
 
 function App() {
@@ -18,6 +20,8 @@ function App() {
           <Route path="/login" element={<Login />} />
           <Route path="/register" element={<Register />} />
           <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/profile" element={<Profile />} />
+          <Route path="/admin" element={<AdminPanel />} />
           <Route path="/aire" element={<Placeholder title="Calidad del Aire" />} />
           <Route path="/extras" element={<Placeholder title="Condiciones Extra" />} />
           <Route path="/mapa" element={<Placeholder title="Mapa de Ubicación" />} />

--- a/frontend/src/Profile.css
+++ b/frontend/src/Profile.css
@@ -1,0 +1,33 @@
+.profile-container {
+  max-width: 600px;
+  margin: 30px auto;
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 12px #0002;
+  text-align: center;
+}
+.profile-email {
+  font-weight: bold;
+  margin-bottom: 20px;
+}
+.pref-row {
+  margin-bottom: 20px;
+}
+.logout-btn {
+  background: #f44336;
+  border: none;
+  color: #fff;
+  padding: 10px 20px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+.admin-link {
+  margin-top: 20px;
+}
+@media (max-width: 600px) {
+  .profile-container {
+    margin: 10px;
+  }
+}

--- a/frontend/src/Profile.test.js
+++ b/frontend/src/Profile.test.js
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Profile from './components/Profile';
+
+jest.mock('./AuthContext', () => ({
+  useAuth: () => ({
+    user: { email: 'test@example.com', user_metadata: {} },
+    supabase: { auth: { signOut: jest.fn() } }
+  }),
+}));
+
+test('renders profile page', () => {
+  render(
+    <MemoryRouter>
+      <Profile />
+    </MemoryRouter>
+  );
+  const heading = screen.getByText(/Perfil de Usuario/i);
+  expect(heading).toBeInTheDocument();
+});

--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import Header from './Header';
+import Placeholder from './Placeholder';
+import { useAuth } from '../AuthContext';
+
+export default function AdminPanel() {
+  const { user } = useAuth();
+  const isAdmin = user?.user_metadata?.is_admin;
+
+  if (!isAdmin) {
+    return <Placeholder title="Acceso restringido" />;
+  }
+
+  return (
+    <div className="dashboard-bg">
+      <Header />
+      <main className="search-section-center" aria-labelledby="admin-title" style={{paddingTop: '20px'}}>
+        <div className="search-box" role="region" aria-label="Panel de administración">
+          <h2 id="admin-title" className="search-box-title">Panel de Administración</h2>
+          <p>Gestione usuarios y configuraciones del sistema.</p>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -5,6 +5,7 @@ import { useAuth } from '../AuthContext';
 
 export default function Header() {
   const { user } = useAuth();
+  const isAdmin = user?.user_metadata?.is_admin;
   return (
     <header className="header">
       <div className="header-title">
@@ -20,11 +21,16 @@ export default function Header() {
         <Link to="/estadisticas">Estadísticas</Link>
         <Link to="/contacto">Contacto</Link>
         {user ? (
-          <span className="profile-circle" title={user.email}></span>
+          <Link to="/profile" aria-label="Perfil">
+            <div className="profile-circle" title={user.email}></div>
+          </Link>
         ) : (
           <Link to="/login" aria-label="Iniciar sesión">
             <div className="profile-circle"></div>
           </Link>
+        )}
+        {isAdmin && (
+          <Link to="/admin" style={{ marginLeft: 8 }}>Admin</Link>
         )}
       </nav>
     </header>

--- a/frontend/src/components/Profile.jsx
+++ b/frontend/src/components/Profile.jsx
@@ -1,0 +1,54 @@
+import React, { useState, useEffect } from 'react';
+import Header from './Header';
+import '../Profile.css';
+import { useAuth } from '../AuthContext';
+
+export default function Profile() {
+  const { user, supabase } = useAuth();
+  const [dark, setDark] = useState(() => localStorage.getItem('pref_dark') === '1');
+
+  useEffect(() => {
+    document.body.classList.toggle('dark-mode', dark);
+    localStorage.setItem('pref_dark', dark ? '1' : '0');
+  }, [dark]);
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut();
+    window.location.href = '/';
+  };
+
+  if (!user) {
+    return (
+      <div className="dashboard-bg">
+        <Header />
+        <main className="search-section-center" aria-labelledby="profile-title" style={{paddingTop: '20px'}}>
+          <div className="search-box">
+            <h2 id="profile-title" className="search-box-title">Inicia sesión para ver tu perfil</h2>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  const isAdmin = user.user_metadata?.is_admin;
+
+  return (
+    <div className="dashboard-bg">
+      <Header />
+      <main className="profile-container" aria-labelledby="profile-title">
+        <h2 id="profile-title">Perfil de Usuario</h2>
+        <p className="profile-email">{user.email}</p>
+        <div className="pref-row">
+          <label>
+            <input type="checkbox" checked={dark} onChange={() => setDark(!dark)} />
+            Modo oscuro
+          </label>
+        </div>
+        <button className="logout-btn" onClick={handleLogout}>Cerrar sesión</button>
+        {isAdmin && (
+          <p className="admin-link"><a href="/admin">Ir al panel de administración</a></p>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -11,3 +11,11 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+body.dark-mode {
+  background: #111;
+  color: #eee;
+}
+body.dark-mode .search-box {
+  background: #222;
+}


### PR DESCRIPTION
## Summary
- create user Profile component and Admin panel
- add dark mode preference and logout functionality
- add routes for new pages
- show profile/admin links in header
- write test for profile page

## Testing
- `npm install --force --prefix frontend`
- `CI=true npm test --silent --runInBand --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68645475c0b0832bacf15067d6621126