### PR TITLE
Share city across dashboard sections

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -15,13 +15,15 @@ import Stats from "./components/Stats";
 import Contact from "./components/Contact";
 import PrivateRoute from "./components/PrivateRoute";
 import { AuthProvider } from "./AuthContext";
+import { WeatherProvider } from "./hooks/useWeather";
 
 function App() {
   return (
     <AuthProvider>
-      <Router basename={process.env.PUBLIC_URL}>
-        <AccessibilityPanel />
-        <Routes>
+      <WeatherProvider>
+        <Router basename={process.env.PUBLIC_URL}>
+          <AccessibilityPanel />
+          <Routes>
           <Route path="/" element={<Welcome />} />
           <Route path="/login" element={<Login />} />
           <Route path="/register" element={<Register />} />
@@ -98,7 +100,8 @@ function App() {
             }
           />
         </Routes>
-      </Router>
+        </Router>
+      </WeatherProvider>
     </AuthProvider>
   );
 }

--- a/frontend/src/components/AirQuality.jsx
+++ b/frontend/src/components/AirQuality.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import Header from './Header';
 import { useWeather } from '../hooks/useWeather';
 import '../Dashboard.css';
@@ -11,8 +11,7 @@ const AQI_TEXT = {
   '5': 'Peligroso',
 };
 export default function AirQuality() {
-  const [city, setCity] = useState('');
-  const { weather, loading, error, search } = useWeather();
+  const { weather, loading, error, search, city, setCity } = useWeather();
 
   return (
     <div className="dashboard-bg">

--- a/frontend/src/components/Alerts.jsx
+++ b/frontend/src/components/Alerts.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import Header from './Header';
 import { useWeather } from '../hooks/useWeather';
 import '../Dashboard.css';
@@ -10,8 +10,7 @@ function overallLevel(alerts) {
   return 'BAJA';
 }
 export default function Alerts() {
-  const [city, setCity] = useState('');
-  const { weather, loading, error, search } = useWeather();
+  const { weather, loading, error, search, city, setCity } = useWeather();
 
   return (
     <div className="dashboard-bg">

--- a/frontend/src/components/Dashboard.js
+++ b/frontend/src/components/Dashboard.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import "../Dashboard.css";
 import { useWeather } from "../hooks/useWeather";
 import { Link } from "react-router-dom";
@@ -65,8 +65,7 @@ function getStatus(type, val) {
 }
 
 function Dashboard() {
-  const [city, setCity] = useState("");
-  const { weather: weatherData, trend, loading, error, search } = useWeather();
+  const { weather: weatherData, trend, loading, error, search, city, setCity } = useWeather();
 
   return (
     <div className="dashboard-container dashboard-bg">

--- a/frontend/src/components/Extras.jsx
+++ b/frontend/src/components/Extras.jsx
@@ -1,11 +1,10 @@
-import React, { useState } from 'react';
+import React from 'react';
 import Header from './Header';
 import { useWeather } from '../hooks/useWeather';
 import '../Dashboard.css';
 
 export default function Extras() {
-  const [city, setCity] = useState('');
-  const { weather, loading, error, search } = useWeather();
+  const { weather, loading, error, search, city, setCity } = useWeather();
 
   return (
     <div className="dashboard-bg">

--- a/frontend/src/components/MapPage.jsx
+++ b/frontend/src/components/MapPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import Header from './Header';
 import { useWeather } from '../hooks/useWeather';
 import '../Dashboard.css';
@@ -17,8 +17,7 @@ L.Marker.prototype.options.icon = L.icon({
   shadowSize: [41, 41],
 });
 export default function MapPage() {
-  const [city, setCity] = useState('');
-  const { weather, loading, error, search } = useWeather();
+  const { weather, loading, error, search, city, setCity } = useWeather();
 
   return (
     <div className="dashboard-bg">

--- a/frontend/src/components/Stats.jsx
+++ b/frontend/src/components/Stats.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import Header from './Header';
 import { useWeather } from '../hooks/useWeather';
 import { mockTrend } from '../data/mockWeather';
@@ -6,8 +6,7 @@ import '../Dashboard.css';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 
 export default function Stats() {
-  const [city, setCity] = useState('');
-  const { weather, trend, loading, error, search } = useWeather();
+  const { weather, trend, loading, error, search, city, setCity } = useWeather();
 
   return (
     <div className="dashboard-bg">


### PR DESCRIPTION
## Summary
- provide `WeatherProvider` context
- wrap app with `WeatherProvider`
- use shared city state in Dashboard and other pages

## Testing
- `npm install --force --prefix frontend`
- `CI=true npm test --silent --runInBand --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6866b26ae180832bbb51eeb8a3e34b6c