### PR TITLE
Add air quality dashboard component

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -8,6 +8,7 @@ import Register from "./components/Register";
 import Profile from "./components/Profile";
 import AdminPanel from "./components/AdminPanel";
 import AirQuality from "./components/AirQuality";
+import AirQualityDashboard from "./components/AirQualityDashboard";
 import Extras from "./components/Extras";
 import MapPage from "./components/MapPage";
 import Alerts from "./components/Alerts";
@@ -56,6 +57,14 @@ function App() {
             element={
               <PrivateRoute>
                 <AirQuality />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path="/aire-dashboard"
+            element={
+              <PrivateRoute>
+                <AirQualityDashboard />
               </PrivateRoute>
             }
           />

--- a/frontend/src/components/AirQualityDashboard.css
+++ b/frontend/src/components/AirQualityDashboard.css
@@ -1,0 +1,280 @@
+.aq-dashboard-container {
+  background: #f7f8fa;
+  min-height: 100vh;
+  font-family: 'Segoe UI', Arial, sans-serif;
+}
+
+.aq-header {
+  background: #222e4e;
+  color: #fff;
+  padding: 8px 0 0 20px;
+}
+
+.aq-modulo-titulo {
+  font-size: 18px;
+  opacity: 0.75;
+}
+
+.aq-navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 40px 10px 0;
+}
+
+.aq-logo {
+  font-weight: bold;
+  margin-right: 16px;
+  color: #2bbef9;
+}
+
+.aq-navbar ul {
+  display: flex;
+  gap: 28px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.aq-navbar li {
+  cursor: pointer;
+  padding: 4px 10px;
+  border-radius: 5px;
+  transition: background 0.2s;
+}
+.aq-navbar li:hover {
+  background: #284a87;
+}
+
+.aq-user-controls {
+  display: flex;
+  gap: 8px;
+}
+
+.aq-btn {
+  background: #183774;
+  border: none;
+  color: #fff;
+  padding: 5px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.aq-main-content {
+  max-width: 1250px;
+  margin: 24px auto;
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 6px 20px #0001;
+  padding: 24px;
+}
+
+.aq-consulta-panel {
+  margin-bottom: 18px;
+  background: #f4f7fb;
+  padding: 14px 18px;
+  border-radius: 12px;
+}
+
+.aq-form-row {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.aq-form-row input, .aq-form-row select {
+  padding: 6px 10px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+}
+
+.aq-btn-aplicar {
+  background: #ffae2a;
+  border: none;
+  color: #fff;
+  font-weight: bold;
+  border-radius: 6px;
+  padding: 6px 18px;
+  cursor: pointer;
+}
+
+.aq-btn-exportar {
+  margin-left: auto;
+  background: #39a3eb;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 6px 18px;
+  cursor: pointer;
+}
+
+.aq-content-panels {
+  display: flex;
+  gap: 20px;
+}
+
+.aq-panel-izq {
+  flex: 0.35;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.aq-panel-der {
+  flex: 0.65;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.aq-card {
+  background: #f8fafc;
+  border-radius: 12px;
+  padding: 16px 22px 14px 22px;
+  box-shadow: 0 2px 8px #0001;
+  margin-bottom: 0;
+}
+
+.aq-card-header {
+  font-weight: bold;
+  margin-bottom: 10px;
+  color: #284a87;
+  font-size: 15px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.aq-aqi-value {
+  font-size: 38px;
+  font-weight: bold;
+  color: #ffae2a;
+  text-align: center;
+  margin: 18px 0 2px 0;
+}
+
+.aq-moderado {
+  background: #ffedb8;
+  color: #af8700;
+  font-weight: 600;
+  padding: 4px 14px;
+  border-radius: 18px;
+  display: inline-block;
+  text-align: center;
+  margin: 0 auto 4px auto;
+  font-size: 13px;
+}
+
+.aq-precaucion {
+  text-align: center;
+  color: #b27e12;
+  font-size: 12px;
+  margin-bottom: 10px;
+}
+
+.aq-escala-ref {
+  margin: 10px 0 0 0;
+}
+
+.aq-escala-bar {
+  display: flex;
+  height: 6px;
+  border-radius: 6px;
+  overflow: hidden;
+  margin-bottom: 4px;
+}
+
+.aq-escala {
+  flex: 1;
+  height: 100%;
+}
+
+.aq-escala.verde { background: #79d672; }
+.aq-escala.amarillo { background: #ffd43b; }
+.aq-escala.naranja { background: #ffaf50; }
+.aq-escala.rojo { background: #eb6060; }
+
+.aq-escala-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  color: #567;
+  margin-top: 2px;
+}
+
+.aq-contaminantes ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.aq-contaminantes li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 7px 0;
+  font-size: 15px;
+}
+
+.aq-value {
+  padding-left: 8px;
+  font-weight: 600;
+  font-size: 14px;
+}
+.aq-value.red { color: #eb6060; }
+.aq-value.orange { color: #ffae2a; }
+.aq-value.yellow { color: #ffd43b; }
+.aq-value.green { color: #79d672; }
+
+.aq-evolucion {
+  min-height: 210px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.aq-grafico-mock {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 130px;
+  color: #a2a2a2;
+}
+
+.aq-grafico-icon {
+  font-size: 38px;
+  margin-bottom: 10px;
+}
+
+.aq-tag-list {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.aq-tag {
+  background: #e3f0fc;
+  color: #367ec7;
+  border-radius: 13px;
+  padding: 2px 12px;
+  font-size: 12px;
+}
+
+.aq-reco-row {
+  display: flex;
+  gap: 28px;
+  font-size: 14px;
+  color: #2a4162;
+  margin-top: 7px;
+}
+.aq-reco-row ul {
+  margin: 6px 0 0 0;
+  padding-left: 16px;
+}
+.aq-actualiza {
+  color: #b9c3cf;
+  font-weight: normal;
+  font-size: 11px;
+  margin-left: 10px;
+}

--- a/frontend/src/components/AirQualityDashboard.jsx
+++ b/frontend/src/components/AirQualityDashboard.jsx
@@ -1,0 +1,154 @@
+import React, { useState } from 'react';
+import { useWeather } from '../hooks/useWeather';
+import './AirQualityDashboard.css';
+
+const AQ_CATEGORY = [
+  { label: 'Buena', max: 50 },
+  { label: 'Moderada', max: 100 },
+  { label: 'Mala', max: 150 },
+  { label: 'Muy Mala', max: Infinity },
+];
+
+export default function AirQualityDashboard() {
+  const { weather, loading, error, search, city, setCity } = useWeather();
+  const [pollutant, setPollutant] = useState('PM2.5');
+
+  const aqi = parseFloat(weather.air.uaqi || weather.air.aqi) || 0;
+  const category = AQ_CATEGORY.find((c) => aqi <= c.max) || AQ_CATEGORY[0];
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    search(city);
+  };
+
+  return (
+    <div className="aq-dashboard-container">
+      <header className="aq-header">
+        <span className="aq-modulo-titulo">Módulo Calidad del Aire</span>
+        <nav className="aq-navbar">
+          <span className="aq-logo">🌎 Dashboard Ambiental</span>
+          <ul>
+            <li>Calidad Aire</li>
+            <li>Calidad Agua</li>
+            <li>Mapa</li>
+            <li>Alertas</li>
+          </ul>
+          <div className="aq-user-controls">
+            <button className="aq-btn">ES</button>
+            <button className="aq-btn">⚙️</button>
+          </div>
+        </nav>
+      </header>
+      <main className="aq-main-content" id="main-content" tabIndex="-1">
+        <section className="aq-consulta-panel" aria-label="Consulta de ubicación">
+          <form className="aq-form-row" onSubmit={handleSubmit}>
+            <input
+              type="text"
+              value={city}
+              onChange={(e) => setCity(e.target.value)}
+              placeholder="Ciudad"
+              aria-label="Ciudad"
+              required
+            />
+            <select value={pollutant} onChange={(e) => setPollutant(e.target.value)}>
+              <option>PM2.5</option>
+              <option>PM10</option>
+              <option>NO₂</option>
+              <option>O₃</option>
+              <option>CO</option>
+            </select>
+            <select>
+              <option>Últimas 24h</option>
+            </select>
+            <button type="submit" className="aq-btn-aplicar">Aplicar</button>
+            <button type="button" className="aq-btn-exportar">Exportar</button>
+          </form>
+          {loading && <p>Consultando...</p>}
+          {error && <p style={{ color: 'red' }}>{error}</p>}
+        </section>
+        <section className="aq-content-panels">
+          <div className="aq-panel-izq">
+            <div className="aq-card aq-aire-index" aria-label="Índice de calidad del aire">
+              <div className="aq-card-header">
+                Índice de Calidad del Aire (AQI)
+                <span className="aq-actualiza">Actualizado: {new Date().toLocaleTimeString('es-ES')}</span>
+              </div>
+              <div className="aq-aqi-value" aria-live="polite">{aqi}</div>
+              <div className="aq-moderado">{category.label.toUpperCase()}</div>
+              <div className="aq-precaucion">Precaución para grupos sensibles</div>
+              <div className="aq-escala-ref">
+                <div className="aq-escala-bar">
+                  <span className="aq-escala verde" />
+                  <span className="aq-escala amarillo" />
+                  <span className="aq-escala naranja" />
+                  <span className="aq-escala rojo" />
+                </div>
+                <div className="aq-escala-labels">
+                  <span>Buena</span>
+                  <span>Moderada</span>
+                  <span>Mala</span>
+                  <span>Muy Mala</span>
+                </div>
+              </div>
+            </div>
+            <div className="aq-card aq-contaminantes" aria-label="Contaminantes individuales">
+              <div className="aq-card-header">Contaminantes Individuales</div>
+              <ul>
+                <li><b>PM2.5</b> <span className="aq-value red">{weather.air.pm25 || '-' } µg/m³</span></li>
+                <li><b>PM10</b> <span className="aq-value orange">{weather.air.pm10 || '-'} µg/m³</span></li>
+                <li><b>NO₂</b> <span className="aq-value yellow">{weather.air.no2 || '-'} µg/m³</span></li>
+                <li><b>O₃</b> <span className="aq-value green">{weather.air.ozone || '-'} µg/m³</span></li>
+                <li><b>CO</b> <span className="aq-value red">{weather.air.co || '-'} µg/m³</span></li>
+              </ul>
+            </div>
+          </div>
+          <div className="aq-panel-der">
+            <div className="aq-card aq-evolucion">
+              <div className="aq-card-header">
+                Evolución Últimas 24 Horas
+                <select value={pollutant} onChange={(e) => setPollutant(e.target.value)}>
+                  <option>PM2.5</option>
+                  <option>PM10</option>
+                  <option>NO₂</option>
+                  <option>O₃</option>
+                  <option>CO</option>
+                </select>
+              </div>
+              <div className="aq-grafico-mock">
+                <div className="aq-grafico-icon">📈</div>
+                <div className="aq-grafico-txt">Gráfico de Evolución {pollutant}<br />Últimas 24 horas</div>
+              </div>
+            </div>
+            <div className="aq-card aq-recomendaciones">
+              <div className="aq-tag-list">
+                <span className="aq-tag">PM2.5</span>
+                <span className="aq-tag">PM10</span>
+                <span className="aq-tag">NO₂</span>
+                <span className="aq-tag">O₃</span>
+              </div>
+              <div className="aq-reco-row">
+                <div>
+                  <b>Recomendaciones de Salud</b>
+                  <ul>
+                    <li>Grupos sensibles: Reducir actividades al aire libre.</li>
+                    <li>Usar mascarilla en exteriores si es necesario.</li>
+                    <li>Mantener ventanas cerradas durante picos.</li>
+                  </ul>
+                </div>
+                <div>
+                  <b>Actividades Recomendadas</b>
+                  <ul>
+                    <li>Ejercicio intenso: No recomendado</li>
+                    <li>Caminata ligera: Aceptable</li>
+                    <li>Actividades manuales: Preferibles</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add a new `AirQualityDashboard` component with API data integration
- add CSS styling for the dashboard
- register new route `/aire-dashboard`

## Testing
- `npm test --silent --runInBand --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866f2e206e8832ba5eae2763d932361