### PR TITLE
Improve usability of forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Demostración de un sistema de monitoreo ambiental con **React** y **Express**. Utiliza Supabase para almacenar usuarios y datos de ejemplo. El repositorio se organiza en dos carpetas principales: `frontend` y `backend`.
 
-La interfaz es **responsiva** y dispone de un panel de accesibilidad que ajusta contraste, tamaño de texto y otros efectos de acuerdo con las pautas **WCAG&nbsp;2.2**. El panel incluye un boton para *restablecer parametros*.
+La interfaz es **responsiva** y dispone de un panel de accesibilidad que ajusta contraste, tamaño de texto y otros efectos de acuerdo con las pautas **WCAG 2.2**. El panel incluye un boton para *restablecer parametros*. Consulta el documento [Usability Checklist](USABILITY_CHECKLIST.md) para ver las practicas aplicadas.
 
 ## Requisitos
 - Node.js 18 o superior

--- a/USABILITY_CHECKLIST.md
+++ b/USABILITY_CHECKLIST.md
@@ -1,0 +1,30 @@
+# Usability Checklist
+
+This project implements several UI components that follow recommendations from **ISO 9241-11** and **ISO 25010:2011**. The main forms and menu were reviewed and updated to include good practices for accessibility and usability.
+
+## System Menu
+- Consistent top location and logical order of options.
+- Active item highlighted through the `active` class on navigation links.
+- Skip link and language switcher for quick access.
+- Responsive layout handled in CSS (`Landing.css`).
+
+## Login Form
+- Explicit labels for email and password fields.
+- Real time validation with messages for incorrect email and weak password.
+- Show/Hide password button with `aria-label`.
+- Autocomplete attributes and new **Remember me** option storing the username locally.
+- Error and success messages announced with `aria-live`.
+
+## Register Form
+- Labels associated with each field and password strength meter.
+- Autocomplete hints (`email`, `new-password`).
+- Show/Hide password button with accessible label.
+- Validation messages displayed while typing.
+
+## Contact Form
+- Single form requesting **Name**, **Email**, **Subject** and **Message**.
+- Required fields and confirmation message after sending.
+- Autocomplete attributes for name and email.
+- Clear instructions and contact information provided.
+
+These adjustments aim to make the application easier to use with keyboards, screen readers and mobile devices while keeping the interface simple.

--- a/frontend/src/components/Contact.jsx
+++ b/frontend/src/components/Contact.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Header from './Header';
 import '../Dashboard.css';
 import '../Profile.css';
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 
 export default function Contact() {
   const { t } = useTranslation();
+  const [sent, setSent] = useState(false);
   return (
     <div className="dashboard-bg">
       <Header />
@@ -22,43 +23,26 @@ export default function Contact() {
             <form
               onSubmit={(e) => {
                 e.preventDefault();
-                alert('Reporte enviado');
-                e.target.reset();
-              }}
-              className="contact-form"
-            >
-              <h3 className="card-title">{t('contact.report')}</h3>
-              <label htmlFor="err-msg">{t('contact.desc')}</label>
-              <textarea id="err-msg" required style={{ width: '100%', minHeight: 80 }} />
-              <button type="submit" style={{ marginTop: 8 }}>{t('contact.send')}</button>
-            </form>
-
-            <form
-              onSubmit={(e) => {
-                e.preventDefault();
-                alert('Gracias por tu sugerencia');
-                e.target.reset();
-              }}
-              className="contact-form"
-            >
-              <h3 className="card-title">{t('contact.tips')}</h3>
-              <label htmlFor="tips-msg">{t('contact.comment')}</label>
-              <textarea id="tips-msg" required style={{ width: '100%', minHeight: 80 }} />
-              <button type="submit" style={{ marginTop: 8 }}>{t('contact.send')}</button>
-            </form>
-
-            <form
-              onSubmit={(e) => {
-                e.preventDefault();
-                alert('Mensaje enviado');
+                setSent(true);
                 e.target.reset();
               }}
               className="contact-form"
             >
               <h3 className="card-title">{t('contact.direct')}</h3>
+              <label htmlFor="contact-name">{t('contact.name')}</label>
+              <input id="contact-name" type="text" required autoComplete="name" style={{ width: '100%' }} />
+              <label htmlFor="contact-email">{t('contact.email')}</label>
+              <input id="contact-email" type="email" required autoComplete="email" style={{ width: '100%' }} />
+              <label htmlFor="contact-subject">{t('contact.subject')}</label>
+              <input id="contact-subject" type="text" required style={{ width: '100%' }} />
               <label htmlFor="contact-msg">{t('contact.message')}</label>
               <textarea id="contact-msg" required style={{ width: '100%', minHeight: 80 }} />
               <button type="submit" style={{ marginTop: 8 }}>{t('contact.send')}</button>
+              {sent && (
+                <div style={{ color: 'green', marginTop: 8 }} aria-live="polite">
+                  {t('contact.sent')}
+                </div>
+              )}
             </form>
           </div>
         </section>

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { FaEye, FaEyeSlash } from "react-icons/fa";
 import { useNavigate, Link } from "react-router-dom";
 import "../Auth.css";
@@ -16,9 +16,18 @@ export default function Login() {
   const [emailError, setEmailError] = useState("");
   const [passError, setPassError] = useState("");
   const [showPass, setShowPass] = useState(false);
+  const [remember, setRemember] = useState(false);
   const navigate = useNavigate();
   const { supabase } = useAuth();
   const status = useSupabaseStatus();
+
+  useEffect(() => {
+    const saved = localStorage.getItem('remember_user');
+    if (saved) {
+      setUser(saved);
+      setRemember(true);
+    }
+  }, []);
 
   const handleEmailChange = (e) => {
     const value = e.target.value;
@@ -41,6 +50,11 @@ export default function Login() {
       password: pass,
     });
     if (!error) {
+      if (remember) {
+        localStorage.setItem('remember_user', user);
+      } else {
+        localStorage.removeItem('remember_user');
+      }
       setMessage(t('login.success'));
       navigate("/dashboard");
     } else {
@@ -72,6 +86,7 @@ export default function Login() {
               onChange={handleEmailChange}
               autoFocus
               required
+              autoComplete="username"
             />
           </div>
           {emailError && (
@@ -88,6 +103,7 @@ export default function Login() {
               value={pass}
               onChange={handlePassChange}
               required
+              autoComplete="current-password"
             />
             <button
               type="button"
@@ -103,6 +119,17 @@ export default function Login() {
               {passError}
             </div>
           )}
+          <div style={{ display: 'flex', alignItems: 'center', marginTop: 8 }}>
+            <input
+              id="remember"
+              type="checkbox"
+              checked={remember}
+              onChange={(e) => setRemember(e.target.checked)}
+            />
+            <label htmlFor="remember" style={{ marginLeft: 6 }}>
+              {t('login.remember')}
+            </label>
+          </div>
           <button className="loginBtn" type="submit">{t('login.submit')}</button>
         </form>
         {loading && <div className="loader" role="status" aria-label="Cargando"></div>}

--- a/frontend/src/components/Register.jsx
+++ b/frontend/src/components/Register.jsx
@@ -82,6 +82,7 @@ export default function Register() {
               onChange={handleEmailChange}
               autoFocus
               required
+              autoComplete="email"
             />
           </div>
           {emailError && (
@@ -98,6 +99,7 @@ export default function Register() {
               value={pass}
               onChange={handlePassChange}
               required
+              autoComplete="new-password"
             />
             <button
               type="button"

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -46,7 +46,8 @@
     "success": "Login successful",
     "error": "Error logging in",
     "noAccount": "Don't have an account?",
-    "register": "Register"
+    "register": "Register",
+    "remember": "Remember me"
   },
   "register": {
     "titleLeft": "Create your account",
@@ -66,12 +67,12 @@
   "contact": {
     "title": "Contact",
     "intro": "Have questions or comments? You can reach us at:",
-    "report": "Report error",
-    "desc": "Description",
-    "send": "Send",
-    "tips": "Send advice",
-    "comment": "Comment",
     "direct": "Direct contact",
-    "message": "Your message"
+    "name": "Name",
+    "email": "Email",
+    "subject": "Subject",
+    "message": "Message",
+    "send": "Send",
+    "sent": "Message sent"
   }
 }

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -46,7 +46,8 @@
     "success": "Login exitoso",
     "error": "Error al iniciar sesión",
     "noAccount": "¿No tienes cuenta?",
-    "register": "Regístrate"
+    "register": "Regístrate",
+    "remember": "Recordar usuario"
   },
   "register": {
     "titleLeft": "Crea tu cuenta",
@@ -66,12 +67,12 @@
   "contact": {
     "title": "Contacto",
     "intro": "¿Tienes dudas o comentarios? Estamos disponibles en:",
-    "report": "Reportar error",
-    "desc": "Descripción",
-    "send": "Enviar",
-    "tips": "Enviar consejo",
-    "comment": "Comentario",
     "direct": "Contacto directo",
-    "message": "Tu mensaje"
+    "name": "Nombre",
+    "email": "Correo",
+    "subject": "Asunto",
+    "message": "Mensaje",
+    "send": "Enviar",
+    "sent": "Mensaje enviado"
   }
 }


### PR DESCRIPTION
## Summary
- add auto-complete and remember-me option on login page
- add auto-complete hints on register page
- replace contact page forms with single accessible form
- add new usability checklist doc and reference it in README
- update translations

## Testing
- `npm test --silent --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68755c6d317c832ba5d88f3f09262f4f