### PR TITLE
Fix header styling and enable skip link

### DIFF
--- a/frontend/src/Dashboard.css
+++ b/frontend/src/Dashboard.css
@@ -7,7 +7,7 @@ body, .dashboard-bg {
 .dashboard-container {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: stretch;
   width: 100%;
 }
 .navbar {

--- a/frontend/src/Landing.css
+++ b/frontend/src/Landing.css
@@ -10,6 +10,8 @@
   align-items: center;
   justify-content: space-between;
   border-radius: 0 0 22px 22px;
+  width: 100%;
+  box-sizing: border-box;
 }
 .header-title {
   display: flex;
@@ -30,6 +32,23 @@
   display: flex;
   align-items: center;
   gap: 15px;
+}
+.lang-switch {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+}
+.lang-switch button {
+  background: #2563eb;
+  color: #fff;
+  border: none;
+  padding: 4px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+.lang-switch button:hover,
+.lang-switch button:focus {
+  background: #114cad;
 }
 .lang-btn {
   background: #2563eb;

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -15,9 +15,9 @@ export default function Header() {
         <div className="header-title">
           <span className="header-main-title">{t('header.mainTitle')}</span>
           <span className="header-subtitle">{t('header.subtitle')}</span>
-          <div className="lang-switch" style={{marginLeft:8}}>
+          <div className="lang-switch">
             <button onClick={() => i18n.changeLanguage('es')}>ES</button>
-            <button onClick={() => i18n.changeLanguage('en')} style={{marginLeft:4}}>EN</button>
+            <button onClick={() => i18n.changeLanguage('en')}>EN</button>
           </div>
         </div>
       <nav className="navbar-links" aria-label="Navegación principal">

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
+import './App.css';
 import App from './App';
 import './i18n';
 import reportWebVitals from './reportWebVitals';


### PR DESCRIPTION
## Summary
- make dashboard header stretch full width
- add language switch styles
- import app styles globally to show skip link
- adjust language buttons markup

## Testing
- `npm install --prefix frontend --legacy-peer-deps`
- `CI=true npm test --silent --runInBand --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6875619b55b4832b9822bd8c154b5a55