### PR TITLE
Display all API alerts

### DIFF
--- a/frontend/src/components/AlertModule.css
+++ b/frontend/src/components/AlertModule.css
@@ -1,0 +1,159 @@
+.alert-module {
+  font-family: 'Segoe UI', sans-serif;
+  padding: 24px;
+  background: #f5f7fa;
+  color: #333;
+}
+
+.alerts-header h2 {
+  margin: 0 0 16px;
+  font-size: 20px;
+}
+
+.stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+}
+
+.stat {
+  background: #fff;
+  border-radius: 8px;
+  padding: 12px 16px;
+  text-align: center;
+  min-width: 120px;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.1);
+}
+.stat-value {
+  display: block;
+  font-size: 24px;
+  font-weight: bold;
+}
+.stat-label {
+  display: block;
+  font-size: 12px;
+  color: #666;
+}
+
+.stat--active   { border-left: 4px solid #dc3545; }
+.stat--today    { border-left: 4px solid #ffc107; }
+.stat--stations { border-left: 4px solid #17a2b8; }
+.stat--response { border-left: 4px solid #28a745; }
+
+.stats-button {
+  margin-left: auto;
+  background: #28a745;
+  color: #fff;
+  border: none;
+  padding: 8px 12px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+}
+
+.alerts-content {
+  display: flex;
+  gap: 24px;
+  margin-top: 32px;
+  flex-wrap: wrap;
+}
+
+.alerts-section {
+  background: #fff;
+  padding: 16px;
+  border-radius: 8px;
+  flex: 1;
+  min-width: 300px;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.1);
+}
+.alerts-section h3 {
+  margin-top: 0;
+}
+
+.alerts-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.alert-card {
+  display: flex;
+  align-items: center;
+  padding: 12px;
+  border-radius: 6px;
+  position: relative;
+}
+.alert-icon {
+  font-size: 20px;
+  margin-right: 12px;
+}
+
+.alert-card--moderate {
+  background: #fff3cd;
+  border: 1px solid #ffeeba;
+}
+.alert-card--moderate .alert-tag {
+  margin-left: auto;
+  padding: 2px 6px;
+  background: #ffc107;
+  color: #333;
+  font-size: 10px;
+  border-radius: 4px;
+}
+
+.alert-card--critical {
+  background: #f8d7da;
+  border: 1px solid #f5c6cb;
+}
+.alert-card--critical .alert-tag {
+  margin-left: auto;
+  padding: 2px 6px;
+  background: #dc3545;
+  color: #fff;
+  font-size: 10px;
+  border-radius: 4px;
+}
+.alert-card--low {
+  background: #d1ecf1;
+  border: 1px solid #bee5eb;
+}
+.alert-card--low .alert-tag {
+  margin-left: auto;
+  padding: 2px 6px;
+  background: #17a2b8;
+  color: #fff;
+  font-size: 10px;
+  border-radius: 4px;
+}
+
+.alert-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.alert-location,
+.alert-time {
+  font-size: 12px;
+  color: #555;
+}
+
+.alert-actions {
+  display: flex;
+  gap: 8px;
+  margin-left: 12px;
+}
+.alert-actions button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 16px;
+  color: #555;
+}
+
+@media (max-width: 800px) {
+  .alerts-content { flex-direction: column; }
+}

--- a/frontend/src/components/Alerts.jsx
+++ b/frontend/src/components/Alerts.jsx
@@ -1,16 +1,37 @@
 import React from 'react';
 import Header from './Header';
 import { useWeather } from '../hooks/useWeather';
-import '../Dashboard.css';
+import './AlertModule.css';
+import { FaExclamationTriangle, FaEye, FaTimesCircle } from 'react-icons/fa';
 
-function overallLevel(alerts) {
-  const vals = Object.values(alerts);
-  if (vals.includes('ALTA')) return 'ALTA';
-  if (vals.includes('MEDIA')) return 'MEDIA';
-  return 'BAJA';
-}
 export default function Alerts() {
   const { weather, loading, error, search, city, setCity } = useWeather();
+
+  const alertEntries = [
+    { key: 'temp', title: 'Temperatura Óptima', value: weather.temperature },
+    { key: 'wind', title: 'Viento Fuerte', value: weather.wind },
+    { key: 'humidity', title: 'Humedad', value: weather.humidity },
+    { key: 'air', title: 'Aire Contaminado', value: weather.air?.pm25 },
+    { key: 'aqi', title: 'Índice AQI', value: weather.air?.aqi },
+    { key: 'uaqi', title: 'Índice UAQI', value: weather.air?.uaqi },
+  ];
+
+  const allAlerts = alertEntries.map((e) => ({
+    ...e,
+    level: weather.alerts[e.key] || '',
+  }));
+
+  const active = allAlerts.filter((a) => a.level && a.level !== 'BAJA');
+
+  const moderateAlerts = active.filter((a) => a.level === 'MEDIA');
+  const criticalAlerts = active.filter((a) => a.level === 'ALTA');
+
+  const stats = [
+    { label: 'Alertas Activas', value: active.length, type: 'active' },
+    { label: 'Alertas Hoy', value: active.length, type: 'today' },
+    { label: 'Estaciones Monit.', value: 1, type: 'stations' },
+    { label: 'Tiempo de Respuesta', value: '<5min', type: 'response' },
+  ];
 
   return (
     <div className="dashboard-bg">
@@ -18,7 +39,7 @@ export default function Alerts() {
       <main id="main-content">
         <section className="search-section-center" aria-labelledby="alerts-title">
           <div className="search-box">
-            <h2 id="alerts-title" className="search-box-title">Alertas</h2>
+            <h2 id="alerts-title" className="search-box-title">Sistema de Alertas Ambientales</h2>
             <form
               className="city-form-horizontal"
               onSubmit={(e) => {
@@ -38,22 +59,86 @@ export default function Alerts() {
             </form>
             {loading && <p>Consultando...</p>}
             {error && <p style={{ color: 'red' }}>{error}</p>}
-            <article
-              className="card"
-              role="region"
-              aria-label="Alertas"
-              style={{ marginTop: 16 }}
-            >
-              <h3 className="card-title">Resultados</h3>
-              <div className="card-row"><span>Temperatura Óptima</span><span>{weather.alerts.temp}</span></div>
-              <div className="card-row"><span>Viento Fuerte</span><span>{weather.alerts.wind}</span></div>
-              <div className="card-row"><span>Humedad</span><span>{weather.alerts.humidity}</span></div>
-              <div className="card-row"><span>Aire Contaminado</span><span>{weather.alerts.air}</span></div>
-              <div className="card-row"><span>Índice AQI</span><span>{weather.alerts.aqi}</span></div>
-              <div className="card-row"><span>Índice UAQI</span><span>{weather.air.uaqi}</span></div>
-              <div className="card-row"><span>Categoría UAQI</span><span>{weather.air.uaqiCategory}</span></div>
-              <div className="card-row"><span>Nivel general</span><span>{overallLevel(weather.alerts)}</span></div>
-            </article>
+            <div className="alert-module" style={{ marginTop: 16 }}>
+              <header className="alerts-header">
+                <div className="stats">
+                  {stats.map((s) => (
+                    <div key={s.type} className={`stat stat--${s.type}`}>
+                      <span className="stat-value">{s.value}</span>
+                      <span className="stat-label">{s.label}</span>
+                    </div>
+                  ))}
+                </div>
+              </header>
+              <div className="alerts-content">
+                <section className="alerts-section alerts-section--moderate">
+                  <h3>Alertas Moderadas</h3>
+                  <div className="alerts-list">
+                    {moderateAlerts.map((a, i) => (
+                      <div key={i} className="alert-card alert-card--moderate">
+                        <FaExclamationTriangle className="alert-icon" />
+                        <div className="alert-info">
+                          <strong>{a.title}</strong>
+                          <span className="alert-location">Nivel {a.level}</span>
+                        </div>
+                        <span className="alert-tag">MODERADA</span>
+                      </div>
+                    ))}
+                    {moderateAlerts.length === 0 && <p>No hay alertas moderadas</p>}
+                  </div>
+                </section>
+                <section className="alerts-section alerts-section--critical">
+                  <h3>Alertas Críticas</h3>
+                  <div className="alerts-list">
+                    {criticalAlerts.map((a, i) => (
+                      <div key={i} className="alert-card alert-card--critical">
+                        <FaExclamationTriangle className="alert-icon" />
+                        <div className="alert-info">
+                          <strong>{a.title}</strong>
+                          <span className="alert-location">Nivel {a.level}</span>
+                        </div>
+                        <span className="alert-tag">CRÍTICA</span>
+                        <div className="alert-actions">
+                          <button title="Ver detalles">
+                            <FaEye />
+                          </button>
+                          <button title="Cerrar alerta">
+                            <FaTimesCircle />
+                          </button>
+                        </div>
+                      </div>
+                    ))}
+                    {criticalAlerts.length === 0 && <p>No hay alertas críticas</p>}
+                  </div>
+                </section>
+                <section className="alerts-section alerts-section--all">
+                  <h3>Todas las Alertas</h3>
+                  <div className="alerts-list">
+                    {allAlerts.map((a, i) => {
+                      const levelClass =
+                        a.level === 'ALTA'
+                          ? 'critical'
+                          : a.level === 'MEDIA'
+                          ? 'moderate'
+                          : 'low';
+                      return (
+                        <div key={i} className={`alert-card alert-card--${levelClass}`}>
+                          <FaExclamationTriangle className="alert-icon" />
+                          <div className="alert-info">
+                            <strong>{a.title}</strong>
+                            {a.value && (
+                              <span className="alert-location">Valor {a.value}</span>
+                            )}
+                            <span className="alert-time">Nivel {a.level || 'N/A'}</span>
+                          </div>
+                          <span className="alert-tag">{a.level || 'N/A'}</span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </section>
+              </div>
+            </div>
           </div>
         </section>
       </main>


### PR DESCRIPTION
## Summary
- include AQI in alert list and map API data into `alertEntries`
- add a section listing all alerts
- style low-level alerts

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6875705fa2c8832b88d73fcad94ed795