### PR TITLE
Improve statistics UI and fix alerts

### DIFF
--- a/frontend/src/components/Alerts.jsx
+++ b/frontend/src/components/Alerts.jsx
@@ -29,28 +29,6 @@ export default function Alerts() {
     { label: 'Tiempo de Respuesta', value: '<5min', type: 'response' },
   ];
 
-  const alertEntries = [
-    { key: 'temp', title: 'Temperatura Óptima' },
-    { key: 'wind', title: 'Viento Fuerte' },
-    { key: 'humidity', title: 'Humedad' },
-    { key: 'air', title: 'Aire Contaminado' },
-    { key: 'uaqi', title: 'Índice UAQI' },
-  ];
-
-  const active = alertEntries
-    .map((e) => ({ ...e, level: weather.alerts[e.key] }))
-    .filter((a) => a.level && a.level !== 'BAJA');
-
-  const moderateAlerts = active.filter((a) => a.level === 'MEDIA');
-  const criticalAlerts = active.filter((a) => a.level === 'ALTA');
-
-  const stats = [
-    { label: 'Alertas Activas', value: active.length, type: 'active' },
-    { label: 'Alertas Hoy', value: active.length, type: 'today' },
-    { label: 'Estaciones Monit.', value: 1, type: 'stations' },
-    { label: 'Tiempo de Respuesta', value: '<5min', type: 'response' },
-  ];
-
   return (
     <div className="dashboard-bg">
       <Header />
@@ -58,25 +36,6 @@ export default function Alerts() {
         <section className="search-section-center" aria-labelledby="alerts-title">
           <div className="search-box">
             <h2 id="alerts-title" className="search-box-title">Sistema de Alertas Ambientales</h2>
-            <form
-              className="city-form-horizontal"
-              onSubmit={(e) => {
-                e.preventDefault();
-                search(city);
-              }}
-            >
-              <label htmlFor="alerts-city">Ciudad</label>
-              <input
-                id="alerts-city"
-                value={city}
-                onChange={(e) => setCity(e.target.value)}
-                placeholder="Ej: Manta"
-                required
-              />
-              <button type="submit">Consultar</button>
-            </form>
-            {loading && <p>Consultando...</p>}
-            {error && <p style={{ color: 'red' }}>{error}</p>}
             <div className="alert-module" style={{ marginTop: 16 }}>
               <header className="alerts-header">
                 <div className="stats">
@@ -132,49 +91,7 @@ export default function Alerts() {
               </div>
             </div>
           </div>
-        </header>
-        <div className="alerts-content">
-          <section className="alerts-section alerts-section--moderate">
-            <h3>Alertas Moderadas</h3>
-            <div className="alerts-list">
-              {moderateAlerts.map((a, i) => (
-                <div key={i} className="alert-card alert-card--moderate">
-                  <FaExclamationTriangle className="alert-icon" />
-                  <div className="alert-info">
-                    <strong>{a.title}</strong>
-                    <span className="alert-location">Nivel {a.level}</span>
-                  </div>
-                  <span className="alert-tag">MODERADA</span>
-                </div>
-              ))}
-              {moderateAlerts.length === 0 && <p>No hay alertas moderadas</p>}
-            </div>
-          </section>
-          <section className="alerts-section alerts-section--critical">
-            <h3>Alertas Críticas</h3>
-            <div className="alerts-list">
-              {criticalAlerts.map((a, i) => (
-                <div key={i} className="alert-card alert-card--critical">
-                  <FaExclamationTriangle className="alert-icon" />
-                  <div className="alert-info">
-                    <strong>{a.title}</strong>
-                    <span className="alert-location">Nivel {a.level}</span>
-                  </div>
-                  <span className="alert-tag">CRÍTICA</span>
-                  <div className="alert-actions">
-                    <button title="Ver detalles">
-                      <FaEye />
-                    </button>
-                    <button title="Cerrar alerta">
-                      <FaTimesCircle />
-                    </button>
-                  </div>
-                </div>
-              ))}
-              {criticalAlerts.length === 0 && <p>No hay alertas críticas</p>}
-            </div>
-          </section>
-        </div>
+        </section>
       </main>
     </div>
   );

--- a/frontend/src/components/StatisticsModule.css
+++ b/frontend/src/components/StatisticsModule.css
@@ -1,0 +1,148 @@
+.stats-module {
+  font-family: 'Segoe UI', sans-serif;
+  padding: 24px;
+  background: #f5f7fa;
+  color: #333;
+}
+
+.stats-header {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.stats-header h2 {
+  margin: 0;
+  font-size: 20px;
+}
+
+.stats-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.stats-filters input,
+.stats-filters select {
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  min-width: 150px;
+}
+
+.btn-generate {
+  padding: 8px 16px;
+  background: #6f42c1;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.btn-export {
+  margin-left: auto;
+  padding: 8px 12px;
+  background: #fff;
+  color: #6f42c1;
+  border: 1px solid #6f42c1;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+}
+
+.stats-content {
+  display: flex;
+  gap: 24px;
+  margin-top: 24px;
+  flex-wrap: wrap;
+}
+
+.stats-sidebar {
+  flex: 1;
+  min-width: 240px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.stat-card {
+  background: #fff;
+  padding: 12px;
+  border-radius: 6px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+.stat-label {
+  display: block;
+  font-size: 12px;
+  color: #666;
+}
+.stat-value {
+  font-size: 18px;
+  font-weight: bold;
+  margin-top: 4px;
+}
+
+.trend-analysis,
+.comparison {
+  background: #fff;
+  padding: 12px;
+  border-radius: 6px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+.trend-analysis h4,
+.comparison h4 {
+  margin: 0 0 8px;
+  font-size: 14px;
+}
+.trend-item,
+.comp-item {
+  display: flex;
+  justify-content: space-between;
+  font-size: 13px;
+  margin-bottom: 6px;
+}
+.trend-value.up,
+.comp-value.up {
+  color: #28a745;
+}
+.trend-value.down,
+.comp-value.down {
+  color: #dc3545;
+}
+
+.stats-chart {
+  flex: 2;
+  min-width: 300px;
+  background: #fff;
+  border-radius: 6px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+  display: flex;
+  flex-direction: column;
+}
+.chart-header {
+  padding: 12px;
+  border-bottom: 1px solid #eee;
+  display: flex;
+  justify-content: flex-end;
+  font-size: 14px;
+}
+.chart-container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Responsive */
+@media (max-width: 800px) {
+  .stats-content {
+    flex-direction: column;
+  }
+  .btn-export {
+    margin-left: 0;
+  }
+}

--- a/frontend/src/components/StatisticsModule.jsx
+++ b/frontend/src/components/StatisticsModule.jsx
@@ -1,0 +1,146 @@
+import React, { useState, useMemo } from 'react';
+import './StatisticsModule.css';
+import { FaDownload } from 'react-icons/fa';
+import { LineChart, BarChart, AreaChart, Line, Bar, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+import { useWeather } from '../hooks/useWeather';
+import { mockTrend } from '../data/mockWeather';
+
+const PARAMS = {
+  temp: 'Temperatura',
+  humidity: 'Humedad',
+  wind: 'Viento',
+};
+
+export default function StatisticsModule() {
+  const { trend, search, city } = useWeather();
+  const [location, setLocation] = useState(city || '');
+  const [parameter, setParameter] = useState('temp');
+  const [chartType, setChartType] = useState('line');
+
+  const data = trend.length ? trend : mockTrend;
+
+  const stats = useMemo(() => {
+    const values = data.map((d) => Number(d[parameter])).filter((n) => !isNaN(n));
+    if (!values.length) {
+      return { avg: 0, max: 0, min: 0, dev: 0, diff: 0 };
+    }
+    const avg = values.reduce((a, b) => a + b, 0) / values.length;
+    const max = Math.max(...values);
+    const min = Math.min(...values);
+    const dev = Math.sqrt(values.reduce((s, v) => s + Math.pow(v - avg, 2), 0) / values.length);
+    const diff = values[values.length - 1] - values[0];
+    return { avg, max, min, dev, diff };
+  }, [data, parameter]);
+
+  const handleGenerate = () => {
+    if (location) search(location);
+  };
+
+  const renderChart = () => {
+    switch (chartType) {
+      case 'bar':
+        return (
+          <BarChart data={data}>
+            <CartesianGrid stroke="#ccc" strokeDasharray="5 5" />
+            <XAxis dataKey="time" />
+            <YAxis />
+            <Tooltip />
+            <Bar dataKey={parameter} fill="#6f42c1" />
+          </BarChart>
+        );
+      case 'area':
+        return (
+          <AreaChart data={data}>
+            <CartesianGrid stroke="#ccc" strokeDasharray="5 5" />
+            <XAxis dataKey="time" />
+            <YAxis />
+            <Tooltip />
+            <Area type="monotone" dataKey={parameter} stroke="#6f42c1" fill="#e1d8f4" />
+          </AreaChart>
+        );
+      default:
+        return (
+          <LineChart data={data}>
+            <CartesianGrid stroke="#ccc" strokeDasharray="5 5" />
+            <XAxis dataKey="time" />
+            <YAxis />
+            <Tooltip />
+            <Line type="monotone" dataKey={parameter} stroke="#6f42c1" />
+          </LineChart>
+        );
+    }
+  };
+
+  return (
+    <div className="stats-module">
+      <header className="stats-header">
+        <h2>Análisis de Datos Históricos</h2>
+
+        <div className="stats-filters">
+          <input
+            type="text"
+            value={location}
+            onChange={(e) => setLocation(e.target.value)}
+            placeholder="Ubicación"
+          />
+          <select value={parameter} onChange={(e) => setParameter(e.target.value)}>
+            <option value="temp">Temperatura</option>
+            <option value="humidity">Humedad</option>
+            <option value="wind">Viento</option>
+          </select>
+          <select value={chartType} onChange={(e) => setChartType(e.target.value)}>
+            <option value="line">Líneas</option>
+            <option value="bar">Barras</option>
+            <option value="area">Área</option>
+          </select>
+          <button className="btn-generate" onClick={handleGenerate}>
+            Generar
+          </button>
+          <button className="btn-export">
+            <FaDownload /> Exportar Reporte
+          </button>
+        </div>
+      </header>
+
+      <div className="stats-content">
+        <aside className="stats-sidebar">
+          <div className="stat-card">
+            <span className="stat-label">Promedio</span>
+            <span className="stat-value">{stats.avg.toFixed(1)}</span>
+          </div>
+          <div className="stat-card">
+            <span className="stat-label">Máximo</span>
+            <span className="stat-value">{stats.max.toFixed(1)}</span>
+          </div>
+          <div className="stat-card">
+            <span className="stat-label">Mínimo</span>
+            <span className="stat-value">{stats.min.toFixed(1)}</span>
+          </div>
+          <div className="stat-card">
+            <span className="stat-label">Desviación</span>
+            <span className="stat-value">±{stats.dev.toFixed(1)}</span>
+          </div>
+
+          <div className="trend-analysis">
+            <h4>Análisis de Tendencias</h4>
+            <div className="trend-item">
+              <span>Tendencia</span>
+              <span className={`trend-value ${stats.diff >= 0 ? 'up' : 'down'}`}>{stats.diff >= 0 ? '+' : ''}{stats.diff.toFixed(1)}</span>
+            </div>
+          </div>
+        </aside>
+
+        <main className="stats-chart">
+          <div className="chart-header">
+            <span>{PARAMS[parameter]}</span>
+          </div>
+          <div className="chart-container">
+            <ResponsiveContainer width="100%" height={300}>
+              {renderChart()}
+            </ResponsiveContainer>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Stats.jsx
+++ b/frontend/src/components/Stats.jsx
@@ -1,57 +1,14 @@
 import React from 'react';
 import Header from './Header';
-import { useWeather } from '../hooks/useWeather';
-import { mockTrend } from '../data/mockWeather';
+import StatisticsModule from './StatisticsModule';
 import '../Dashboard.css';
-import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 
 export default function Stats() {
-  const { weather, trend, loading, error, search, city, setCity } = useWeather();
-
   return (
     <div className="dashboard-bg">
       <Header />
       <main id="main-content">
-        <section className="search-section-center" aria-labelledby="stats-title">
-          <div className="search-box">
-            <h2 id="stats-title" className="search-box-title">Estadísticas</h2>
-            <form
-              className="city-form-horizontal"
-              onSubmit={(e) => {
-                e.preventDefault();
-                search(city);
-              }}
-            >
-              <label htmlFor="stats-city">Ciudad</label>
-              <input
-                id="stats-city"
-                value={city}
-                onChange={(e) => setCity(e.target.value)}
-                placeholder="Ej: Manta"
-                required
-              />
-              <button type="submit">Consultar</button>
-            </form>
-            {loading && <p>Consultando...</p>}
-            {error && <p style={{ color: 'red' }}>{error}</p>}
-            <div className="map-box" style={{ marginTop: 16 }}>
-              <ResponsiveContainer width="100%" height={220}>
-                <LineChart data={trend.length ? trend : mockTrend}>
-                  <CartesianGrid stroke="#ccc" strokeDasharray="5 5" />
-                  <XAxis dataKey="time" />
-                  <YAxis />
-                  <Tooltip />
-                  <Line type="monotone" dataKey="temp" stroke="#8884d8" name="Temp" />
-                  <Line type="monotone" dataKey="humidity" stroke="#82ca9d" name="Humedad" />
-                  <Line type="monotone" dataKey="wind" stroke="#ff7300" name="Viento" />
-                </LineChart>
-              </ResponsiveContainer>
-            </div>
-            {weather.air.uaqi && (
-              <p style={{marginTop:10}}>UAQI actual: {weather.air.uaqi} - {weather.air.uaqiCategory}</p>
-            )}
-          </div>
-        </section>
+        <StatisticsModule />
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- add `StatisticsModule` component with improved charts
- style statistics with new CSS module
- simplify `Stats` page to use the new module
- fix duplicated code in `Alerts` component

## Testing
- `npm test --silent --runInBand --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_687575c19e7c832b97daef1cdba3c041