### PR TITLE
Implement functional forecast chart in extras

### DIFF
--- a/frontend/src/components/Extras.jsx
+++ b/frontend/src/components/Extras.jsx
@@ -1,15 +1,19 @@
 import React from 'react';
 import Header from './Header';
 import { useWeather } from '../hooks/useWeather';
+import ExtrasChart from './ExtrasChart';
+import { mockTrend } from '../data/mockWeather';
 import './AirQualityDashboard.css';
 
 export default function Extras() {
-  const { weather, loading, error, search, city, setCity } = useWeather();
+  const { weather, trend, loading, error, search, city, setCity } = useWeather();
 
   const handleSubmit = (e) => {
     e.preventDefault();
     search(city);
   };
+
+  const data = trend.length ? trend : mockTrend;
 
   return (
     <div className="aq-dashboard-container">
@@ -53,10 +57,16 @@ export default function Extras() {
           <div className="aq-panel-der">
             <div className="aq-card aq-evolucion">
               <div className="aq-card-header">Pronóstico</div>
-              <div className="aq-grafico-mock">
-                <div className="aq-grafico-icon">📈</div>
-                <div className="aq-grafico-txt">Gráfico de tendencia<br />Próximas horas</div>
-              </div>
+              {data.length ? (
+                <div className="aq-grafico">
+                  <ExtrasChart data={data} />
+                </div>
+              ) : (
+                <div className="aq-grafico-mock">
+                  <div className="aq-grafico-icon">📈</div>
+                  <div className="aq-grafico-txt">Gráfico de tendencia<br />Próximas horas</div>
+                </div>
+              )}
             </div>
           </div>
         </section>

--- a/frontend/src/components/ExtrasChart.jsx
+++ b/frontend/src/components/ExtrasChart.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+
+export default function ExtrasChart({ data }) {
+  return (
+    <ResponsiveContainer width="100%" height={180}>
+      <LineChart data={data} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
+        <CartesianGrid stroke="#ccc" strokeDasharray="5 5" />
+        <XAxis dataKey="time" />
+        <YAxis />
+        <Tooltip />
+        <Legend />
+        <Line type="monotone" dataKey="temp" stroke="#ff7f0e" name="Temp. °C" />
+        <Line type="monotone" dataKey="humidity" stroke="#1f77b4" name="Humedad %" />
+        <Line type="monotone" dataKey="wind" stroke="#2ca02c" name="Viento m/s" />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}


### PR DESCRIPTION
## Summary
- add ExtrasChart component using recharts
- show forecast line chart on Extras page with fallback to mock data

## Testing
- `npm install --force --prefix frontend`
- `CI=true npm test --runInBand --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_687580170fa0832b9f1595f05c5f76de