### PR TITLE
Fix missing navigation on contact page

### DIFF
--- a/frontend/src/components/ContactoAyuda.jsx
+++ b/frontend/src/components/ContactoAyuda.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import '../ContactoAyuda.css';
+import Header from './Header';
 
 export default function ContactoAyuda() {
   return (
-    <div className="contacto-main">
+    <div className="dashboard-bg">
+      <Header />
+      <div className="contacto-main">
       {/* Encabezado */}
       <div className="contacto-header">
         <div className="contacto-header-icon">?</div>
@@ -145,6 +148,7 @@ export default function ContactoAyuda() {
             </form>
           </div>
         </div>
+      </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- include the shared Header on the contact page

## Testing
- `npm install --force`
- `CI=true npm test --silent --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_687583475c70832b9dccf4fe412933b3