### PR TITLE
Add user initials and history dashboard

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -17,6 +17,7 @@ import ContactoAyuda from "./components/ContactoAyuda";
 import PrivateRoute from "./components/PrivateRoute";
 import { AuthProvider } from "./AuthContext";
 import { WeatherProvider } from "./hooks/useWeather";
+import UserHistoryDashboard from "./components/UserHistoryDashboard";
 
 function App() {
   return (
@@ -105,6 +106,14 @@ function App() {
             element={
               <PrivateRoute>
                 <ContactoAyuda />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path="/historial"
+            element={
+              <PrivateRoute>
+                <UserHistoryDashboard />
               </PrivateRoute>
             }
           />

--- a/frontend/src/Landing.css
+++ b/frontend/src/Landing.css
@@ -66,6 +66,11 @@
   border-radius: 50%;
   background: #eee;
   border: 2px solid #b0d3fa;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  color: #2563eb;
 }
 .central-panel {
   background: linear-gradient(120deg, #2067d8 70%, #47a3fa 100%);

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -8,6 +8,9 @@ export default function Header() {
   const { t, i18n } = useTranslation();
   const { user } = useAuth();
   const isAdmin = user?.user_metadata?.is_admin;
+  const initials = user?.email
+    ? user.email.split('@')[0].slice(0, 2).toUpperCase()
+    : '';
   return (
     <>
       <a href="#main-content" className="skip-link">{t('header.skip')}</a>
@@ -69,7 +72,7 @@ export default function Header() {
               aria-label="Perfil"
               className={({ isActive }) => (isActive ? 'active' : '')}
             >
-              <div className="profile-circle" title={user.email}></div>
+              <div className="profile-circle" title={user.email}>{initials}</div>
             </NavLink>
           ) : (
             <NavLink

--- a/frontend/src/components/UserHistoryDashboard.css
+++ b/frontend/src/components/UserHistoryDashboard.css
@@ -1,0 +1,303 @@
+/* Background and layout */
+.dashboard-bg {
+  background: #756e6e;
+  min-height: 100vh;
+  padding: 20px 0;
+}
+.dashboard-container {
+  background: #f6f8fa;
+  margin: 40px auto;
+  max-width: 950px;
+  border-radius: 18px;
+  box-shadow: 0 8px 24px rgba(54, 69, 79, 0.10);
+  padding: 30px 28px 32px 28px;
+}
+
+/* User Card */
+.user-card {
+  display: flex;
+  align-items: center;
+  background: #fff;
+  border-radius: 14px;
+  padding: 24px;
+  box-shadow: 0 2px 8px rgba(160, 176, 185, 0.10);
+  margin-bottom: 22px;
+  gap: 22px;
+}
+.user-avatar {
+  width: 74px;
+  height: 74px;
+  border-radius: 50%;
+  background: #c5daf8;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 1.3em;
+  color: #23408e;
+}
+.user-info {
+  flex: 1;
+}
+.user-name {
+  font-weight: 700;
+  font-size: 1.14em;
+  margin-bottom: 3px;
+}
+.user-email {
+  font-size: 0.99em;
+  color: #60708d;
+  margin-bottom: 12px;
+}
+.user-stats {
+  display: flex;
+  gap: 36px;
+  margin-bottom: 4px;
+}
+.user-stat-number {
+  font-weight: 700;
+  font-size: 1.07em;
+  color: #2172e5;
+  margin-right: 4px;
+}
+.user-stat-number.green {
+  color: #28c179;
+}
+.user-stat-label {
+  font-size: 0.93em;
+  color: #7589a6;
+  margin-right: 7px;
+}
+.user-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.btn {
+  padding: 7px 18px;
+  border-radius: 7px;
+  border: none;
+  font-weight: 600;
+  font-size: 1em;
+  cursor: pointer;
+  margin-bottom: 3px;
+}
+.btn.green {
+  background: #22be74;
+  color: #fff;
+}
+.btn.export {
+  background: #f6f8fa;
+  color: #2172e5;
+  border: 1px solid #d4e3f8;
+}
+.btn.apply {
+  background: #3676e7;
+  color: #fff;
+  margin-left: 12px;
+}
+.btn.clear {
+  background: #f6f8fa;
+  color: #7589a6;
+  border: 1px solid #d7dfe8;
+  margin-left: 8px;
+}
+
+/* Filter Bar */
+.filter-bar {
+  background: #fff;
+  border-radius: 13px;
+  margin-bottom: 18px;
+  padding: 18px 22px 12px 22px;
+}
+.filter-row {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+.filter-input {
+  flex: 1.2;
+  border: 1px solid #d7dfe8;
+  border-radius: 7px;
+  padding: 7px 14px;
+  font-size: 1em;
+  outline: none;
+  background: #f6f8fa;
+}
+.filter-select {
+  border: 1px solid #d7dfe8;
+  border-radius: 7px;
+  padding: 7px 13px;
+  background: #f6f8fa;
+  font-size: 1em;
+  min-width: 130px;
+  outline: none;
+}
+
+/* History Section */
+.history-section {
+  margin-top: 8px;
+}
+.history-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 9px;
+  font-size: 1.09em;
+}
+.results-count {
+  font-weight: 500;
+  color: #2172e5;
+}
+.order-select {
+  border: 1px solid #d7dfe8;
+  border-radius: 7px;
+  padding: 6px 13px;
+  background: #f6f8fa;
+  font-size: 1em;
+}
+
+/* History Card */
+.history-card {
+  display: flex;
+  background: #fff;
+  border-radius: 14px;
+  box-shadow: 0 2px 8px rgba(160, 176, 185, 0.10);
+  margin-bottom: 16px;
+  padding: 20px 28px 18px 0;
+}
+.history-card-left {
+  display: flex;
+  align-items: flex-start;
+  padding-left: 25px;
+  padding-top: 8px;
+  margin-right: 18px;
+}
+.alert-circle {
+  background: #e15a5a;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.icon-alert {
+  display: inline-block;
+  width: 28px;
+  height: 28px;
+  background: url('data:image/svg+xml;utf8,<svg width="28" height="28" fill="white" viewBox="0 0 24 24" ><path d="M13 16h-2v-2h2zm0-4h-2V7h2zm8.83 7l-1.41-1.41A9.969 9.969 0 0022 12c0-5.52-4.48-10-10-10S2 6.48 2 12c0 2.08.64 4.02 1.76 5.62L2.83 19c-.2.2-.2.51 0 .71s.51.2.71 0l1.54-1.54A9.985 9.985 0 0012 22c5.52 0 10-4.48 10-10 0-2.08-.64-4.02-1.76-5.62z"></path></svg>')
+    center/contain no-repeat;
+}
+
+/* Card content */
+.history-card-body {
+  flex: 1;
+}
+.history-title-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+.history-title {
+  font-weight: 700;
+  font-size: 1.09em;
+}
+.history-date {
+  color: #7589a6;
+  font-size: 0.96em;
+}
+.history-description {
+  color: #697fa5;
+  margin-top: 4px;
+  margin-bottom: 9px;
+  font-size: 0.97em;
+}
+.history-params {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  flex-wrap: wrap;
+  margin-bottom: 13px;
+  font-size: 0.99em;
+}
+.param-label {
+  color: #7589a6;
+  font-size: 0.97em;
+  margin-right: 3px;
+}
+.param-badge {
+  display: inline-block;
+  padding: 3px 9px;
+  border-radius: 7px;
+  font-size: 0.98em;
+  color: #3a3e48;
+  font-weight: 500;
+  margin-right: 3px;
+}
+.aqi-badge {
+  background: #ffe099;
+  color: #ad7a1c;
+  border-radius: 7px;
+  padding: 3px 9px;
+  margin-right: 3px;
+  font-weight: 600;
+}
+.alerts-badge {
+  background: #e15a5a;
+  color: #fff;
+  border-radius: 7px;
+  padding: 3px 9px;
+  font-weight: 600;
+}
+
+/* Actions */
+.history-actions {
+  display: flex;
+  gap: 13px;
+  margin-top: 8px;
+}
+.icon-btn {
+  border: none;
+  background: #f6f8fa;
+  border-radius: 7px;
+  width: 38px;
+  height: 38px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.18s;
+}
+.icon-btn:hover {
+  background: #d8eaff;
+}
+.icon-btn.repeat::before {
+  content: "⟳";
+  font-size: 1.25em;
+  color: #22be74;
+}
+.icon-btn.fav::before {
+  content: "♥";
+  font-size: 1.17em;
+  color: #e95966;
+}
+.icon-btn.download::before {
+  content: "⇩";
+  font-size: 1.15em;
+  color: #4675e7;
+}
+
+/* Empty card for spacing */
+.history-empty-card {
+  height: 56px;
+}
+
+/* Responsive */
+@media (max-width: 800px) {
+  .dashboard-container { padding: 10px; }
+  .user-card, .filter-bar, .history-card { flex-direction: column; align-items: flex-start; }
+  .user-actions { flex-direction: row; }
+  .filter-row { flex-direction: column; gap: 10px; }
+  .history-title-row { flex-direction: column; align-items: flex-start; gap: 3px; }
+}

--- a/frontend/src/components/UserHistoryDashboard.jsx
+++ b/frontend/src/components/UserHistoryDashboard.jsx
@@ -1,0 +1,146 @@
+import React from "react";
+import Header from "./Header";
+import "./UserHistoryDashboard.css";
+
+const historyData = [
+  {
+    title: "Calidad del Aire - Valencia Centro",
+    date: "Hoy, 14:30",
+    parameters: [
+      { name: "PM2.5", color: "#E15A5A" },
+      { name: "NO₂", color: "#F9A84F" },
+      { name: "O₃", color: "#FFD96A" },
+      { name: "CO", color: "#7DE3B1" },
+    ],
+    aqi: 78,
+    aqiLabel: "MODERADO",
+    aqiColor: "#FFD96A",
+    alerts: 2,
+    alertColor: "#E15A5A",
+  },
+];
+
+export default function UserHistoryDashboard() {
+  const userName = "Dr. María González Rodríguez";
+  const initials = userName
+    .split(/\s+/)
+    .map((n) => n[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+
+  return (
+    <div className="dashboard-bg">
+      <Header />
+      <div className="dashboard-container">
+        {/* User Card */}
+        <div className="user-card">
+          <div className="user-avatar">{initials}</div>
+          <div className="user-info">
+            <div className="user-name">{userName}</div>
+            <div className="user-email">maria.gonzalez@universidad.es</div>
+            <div className="user-stats">
+              <div>
+                <span className="user-stat-number">247</span>
+                <span className="user-stat-label">Búsquedas totales</span>
+              </div>
+              <div>
+                <span className="user-stat-number green">18</span>
+                <span className="user-stat-label">Esta semana</span>
+              </div>
+              <div>
+                <span className="user-stat-number">5</span>
+                <span className="user-stat-label">Favoritas</span>
+              </div>
+            </div>
+          </div>
+          <div className="user-actions">
+            <button className="btn green">+ Nueva Búsqueda</button>
+            <button className="btn export">Exportar</button>
+          </div>
+        </div>
+
+        {/* Filter Bar */}
+        <div className="filter-bar">
+          <div className="filter-row">
+            <input
+              className="filter-input"
+              placeholder="Buscar por ubicación, tipo..."
+            />
+            <select className="filter-select">
+              <option>Todas las consultas</option>
+            </select>
+            <select className="filter-select">
+              <option>Últimos 30 días</option>
+            </select>
+            <select className="filter-select">
+              <option>Todos</option>
+            </select>
+            <button className="btn apply">Aplicar</button>
+            <button className="btn clear">Limpiar</button>
+          </div>
+        </div>
+
+        {/* History List */}
+        <div className="history-section">
+          <div className="history-header">
+            <span>
+              Historial de Búsquedas{" "}
+              <span className="results-count">(247 resultados)</span>
+            </span>
+            <select className="order-select">
+              <option>Más reciente</option>
+            </select>
+          </div>
+
+          {/* History Card */}
+          {historyData.map((item, i) => (
+            <div className="history-card" key={i}>
+              <div className="history-card-left">
+                <div className="alert-circle">
+                  <span className="icon-alert" />
+                </div>
+              </div>
+              <div className="history-card-body">
+                <div className="history-title-row">
+                  <span className="history-title">{item.title}</span>
+                  <span className="history-date">{item.date}</span>
+                </div>
+                <div className="history-description">
+                  Consulta completa de contaminantes atmosféricos
+                </div>
+                <div className="history-params">
+                  <span className="param-label">Parámetros consultados:</span>
+                  {item.parameters.map((p, idx) => (
+                    <span
+                      key={idx}
+                      className="param-badge"
+                      style={{ background: p.color }}
+                    >
+                      {p.name}
+                    </span>
+                  ))}
+                  <span className="param-label">Resultados obtenidos:</span>
+                  <span className="aqi-badge" style={{ background: item.aqiColor }}>
+                    AQI {item.aqi} {item.aqiLabel}
+                  </span>
+                  <span className="alerts-badge" style={{ background: item.alertColor }}>
+                    {item.alerts} Alertas
+                  </span>
+                </div>
+                <div className="history-actions">
+                  <button className="icon-btn repeat" title="Repetir"></button>
+                  <button className="icon-btn fav" title="Favorito"></button>
+                  <button className="icon-btn download" title="Descargar"></button>
+                </div>
+              </div>
+            </div>
+          ))}
+
+          {/* Placeholder for more results */}
+          <div className="history-empty-card"></div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- show user's initials in the header profile circle
- tweak header CSS to center the initials
- add a UserHistoryDashboard component and styles
- register `/historial` route for new dashboard

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68758857cd94832b9b9499d1e28bbda0