### PR TITLE
Add color-coded extras list

### DIFF
--- a/frontend/src/components/AirQualityDashboard.css
+++ b/frontend/src/components/AirQualityDashboard.css
@@ -288,9 +288,9 @@
   list-style: none;
   margin: 0;
   padding: 0;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 8px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .aq-extras-list li {

--- a/frontend/src/components/Extras.jsx
+++ b/frontend/src/components/Extras.jsx
@@ -5,6 +5,34 @@ import ExtrasChart from './ExtrasChart';
 import { mockTrend } from '../data/mockWeather';
 import './AirQualityDashboard.css';
 
+function parseNum(value) {
+  const n = parseFloat(String(value).replace(/[^0-9.-]/g, ''));
+  return Number.isNaN(n) ? null : n;
+}
+
+function getColor(key, value) {
+  const v = parseNum(value);
+  if (v === null) return '';
+  switch (key) {
+    case 'feelsLike':
+    case 'tempMin':
+    case 'tempMax':
+      return v > 30 ? 'red' : v > 20 ? 'yellow' : 'green';
+    case 'clouds':
+      return v > 80 ? 'red' : v > 50 ? 'yellow' : 'green';
+    case 'visibility':
+      return v < 5000 ? 'red' : v < 10000 ? 'yellow' : 'green';
+    case 'pressure':
+      return v < 1000 ? 'red' : v < 1010 ? 'yellow' : 'green';
+    case 'humidity':
+      return v > 80 ? 'red' : v > 60 ? 'yellow' : 'green';
+    case 'wind':
+      return v > 10 ? 'red' : v > 5 ? 'yellow' : 'green';
+    default:
+      return '';
+  }
+}
+
 export default function Extras() {
   const { weather, trend, loading, error, search, city, setCity } = useWeather();
 
@@ -42,7 +70,7 @@ export default function Extras() {
               <ul className="aq-extras-list">
                 <li>
                   <span>Sensación térmica</span>
-                  <span className="aq-value">{weather.extras.feelsLike}</span>
+                  <span className={`aq-value ${getColor('feelsLike', weather.extras.feelsLike)}`}>{weather.extras.feelsLike}</span>
                 </li>
                 <li>
                   <span>Estado del cielo</span>
@@ -50,19 +78,19 @@ export default function Extras() {
                 </li>
                 <li>
                   <span>Nubosidad</span>
-                  <span className="aq-value">{weather.extras.clouds}</span>
+                  <span className={`aq-value ${getColor('clouds', weather.extras.clouds)}`}>{weather.extras.clouds}</span>
                 </li>
                 <li>
                   <span>Visibilidad</span>
-                  <span className="aq-value">{weather.extras.visibility}</span>
+                  <span className={`aq-value ${getColor('visibility', weather.extras.visibility)}`}>{weather.extras.visibility}</span>
                 </li>
                 <li>
                   <span>Temp. mínima</span>
-                  <span className="aq-value">{weather.extras.tempMin}</span>
+                  <span className={`aq-value ${getColor('tempMin', weather.extras.tempMin)}`}>{weather.extras.tempMin}</span>
                 </li>
                 <li>
                   <span>Temp. máxima</span>
-                  <span className="aq-value">{weather.extras.tempMax}</span>
+                  <span className={`aq-value ${getColor('tempMax', weather.extras.tempMax)}`}>{weather.extras.tempMax}</span>
                 </li>
                 <li>
                   <span>Amanecer</span>
@@ -74,15 +102,15 @@ export default function Extras() {
                 </li>
                 <li>
                   <span>Presión atmosférica</span>
-                  <span className="aq-value">{weather.pressure}</span>
+                  <span className={`aq-value ${getColor('pressure', weather.pressure)}`}>{weather.pressure}</span>
                 </li>
                 <li>
                   <span>Humedad</span>
-                  <span className="aq-value">{weather.humidity}</span>
+                  <span className={`aq-value ${getColor('humidity', weather.humidity)}`}>{weather.humidity}</span>
                 </li>
                 <li>
                   <span>Viento</span>
-                  <span className="aq-value">{weather.wind}</span>
+                  <span className={`aq-value ${getColor('wind', weather.wind)}`}>{weather.wind}</span>
                 </li>
               </ul>
             </div>


### PR DESCRIPTION
## Summary
- add helper functions to determine color class for extras values
- layout extras list vertically
- style extras value text with green/yellow/red

## Testing
- `npm install --force`
- `CI=true npm test --silent --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_687588a5021c832ba0a01d0ae2f621dd