### PR TITLE
Enable functional real-time map on dashboard

### DIFF
--- a/frontend/src/DashboardAmbiente.css
+++ b/frontend/src/DashboardAmbiente.css
@@ -127,7 +127,15 @@
   margin-bottom: 20px;
   box-shadow: 0 1px 7px 0 #d2e7f8;
 }
-.mapa-interactivo { background: #d7f2ed; border-radius: 12px; padding: 30px 0; text-align: center; font-size: 1.2em; margin-bottom: 12px; }
+.mapa-interactivo {
+  background: #d7f2ed;
+  border-radius: 12px;
+  padding: 10px;
+  text-align: center;
+  margin-bottom: 12px;
+  display: flex;
+  justify-content: center;
+}
 .estaciones-relevantes ul { list-style: none; padding: 0; margin: 0; }
 .estaciones-relevantes li { padding: 5px 0; }
 .estaciones-relevantes li.ok { color: #009d72; }

--- a/frontend/src/components/Dashboard.js
+++ b/frontend/src/components/Dashboard.js
@@ -3,6 +3,8 @@ import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContai
 import '../DashboardAmbiente.css';
 import { useWeather } from '../hooks/useWeather';
 import Header from './Header';
+import RealTimeMap from './RealTimeMap';
+import { mockWeather } from '../data/mockWeather';
 
 export default function Dashboard() {
   const { weather, loading, error, search, city, setCity } = useWeather();
@@ -184,7 +186,11 @@ export default function Dashboard() {
       <section className="mapa-estaciones">
         <h4>Mapa de Estaciones en Tiempo Real</h4>
         <div className="mapa-interactivo">
-          <div className="mapa-icon">Vista Interactiva del Territorio</div>
+          <RealTimeMap
+            lat={weather.lat || mockWeather.lat}
+            lon={weather.lon || mockWeather.lon}
+            height="200px"
+          />
         </div>
         <div className="estaciones-relevantes">
           <b>Estaciones Más Relevantes</b>

--- a/frontend/src/components/MapPage.jsx
+++ b/frontend/src/components/MapPage.jsx
@@ -2,20 +2,8 @@ import React from 'react';
 import Header from './Header';
 import { useWeather } from '../hooks/useWeather';
 import './InteractiveMapDashboard.css';
-import { MapContainer, TileLayer, Marker } from 'react-leaflet';
-import 'leaflet/dist/leaflet.css';
-import L from 'leaflet';
-import markerIcon from 'leaflet/dist/images/marker-icon.png';
-import markerShadow from 'leaflet/dist/images/marker-shadow.png';
+import RealTimeMap from './RealTimeMap';
 import { mockWeather } from '../data/mockWeather';
-
-L.Marker.prototype.options.icon = L.icon({
-  iconUrl: markerIcon,
-  shadowUrl: markerShadow,
-  iconSize: [25, 41],
-  iconAnchor: [12, 41],
-  shadowSize: [41, 41],
-});
 export default function MapPage() {
   const { weather, loading, error, search, city, setCity } = useWeather();
 
@@ -83,15 +71,13 @@ export default function MapPage() {
             </div>
           </div>
           <div className="imd-mapa-box">
-            <MapContainer
+            <RealTimeMap
               key={`${weather.lat || mockWeather.lat},${weather.lon || mockWeather.lon}`}
-              center={[weather.lat || mockWeather.lat, weather.lon || mockWeather.lon]}
-              zoom={10}
-              style={{ height: '280px', width: '90%' }}
-            >
-              <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
-              <Marker position={[weather.lat || mockWeather.lat, weather.lon || mockWeather.lon]} />
-            </MapContainer>
+              lat={weather.lat || mockWeather.lat}
+              lon={weather.lon || mockWeather.lon}
+              width="90%"
+              height="280px"
+            />
           </div>
           <div className="imd-mapa-footer">
             <div className="imd-footer-info">

--- a/frontend/src/components/RealTimeMap.jsx
+++ b/frontend/src/components/RealTimeMap.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { MapContainer, TileLayer, Marker } from 'react-leaflet';
+import 'leaflet/dist/leaflet.css';
+import L from 'leaflet';
+import markerIcon from 'leaflet/dist/images/marker-icon.png';
+import markerShadow from 'leaflet/dist/images/marker-shadow.png';
+
+L.Marker.prototype.options.icon = L.icon({
+  iconUrl: markerIcon,
+  shadowUrl: markerShadow,
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  shadowSize: [41, 41],
+});
+
+export default function RealTimeMap({ lat, lon, height = '280px', width = '100%' }) {
+  if (lat == null || lon == null) {
+    return null;
+  }
+
+  return (
+    <MapContainer center={[lat, lon]} zoom={10} style={{ height, width }}>
+      <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+      <Marker position={[lat, lon]} />
+    </MapContainer>
+  );
+}


### PR DESCRIPTION
## Summary
- create reusable `RealTimeMap` component using `react-leaflet`
- render `RealTimeMap` in `MapPage` and `Dashboard` for live station display
- adjust map container styles
- update tests (install deps and run)

## Testing
- `npm install --force --prefix frontend`
- `CI=true npm test --silent --runInBand --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6875903c1cec832b879b77addc31c932