### PR TITLE
Ensure fixed header on auth pages

### DIFF
--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -6,6 +6,7 @@ import logo from "../logo.svg";
 import { useAuth } from "../AuthContext";
 import { useSupabaseStatus } from "../hooks/useSupabaseStatus";
 import { useTranslation } from 'react-i18next';
+import Header from './Header';
 
 export default function Login() {
   const { t } = useTranslation();
@@ -64,15 +65,18 @@ export default function Login() {
   }
 
   return (
-    <div className="login-container">
-      <div className="login-leftPanel">
-        <div className="logoCircle">
-          <img src={logo} alt="logo" width="40" />
-        </div>
-        <h2 className="welcome">{t('login.welcome')}</h2>
-        <p className="desc">{t('login.desc')}</p>
-      </div>
-      <div className="login-rightPanel">
+    <div className="dashboard-bg">
+      <Header />
+      <main id="main-content">
+        <div className="login-container">
+          <div className="login-leftPanel">
+            <div className="logoCircle">
+              <img src={logo} alt="logo" width="40" />
+            </div>
+            <h2 className="welcome">{t('login.welcome')}</h2>
+            <p className="desc">{t('login.desc')}</p>
+          </div>
+          <div className="login-rightPanel">
         <h2 className="loginTitle">{t('login.title')}</h2>
         <p className="loginDesc">{t('login.formDesc')}</p>
         <form className="form" onSubmit={handleSubmit} aria-label={t('login.title')}>
@@ -146,6 +150,8 @@ export default function Login() {
           <Link className="registerLink" to="/register">{t('login.register')}</Link>
         </p>
       </div>
+        </div>
+      </main>
     </div>
   );
 }

--- a/frontend/src/components/Register.jsx
+++ b/frontend/src/components/Register.jsx
@@ -6,6 +6,7 @@ import logo from '../logo.svg';
 import { useAuth } from '../AuthContext';
 import { useSupabaseStatus } from '../hooks/useSupabaseStatus';
 import { useTranslation } from 'react-i18next';
+import Header from './Header';
 
 export default function Register() {
   const { t } = useTranslation();
@@ -60,15 +61,18 @@ export default function Register() {
   }
 
   return (
-    <div className="register-container">
-      <div className="register-leftPanel">
-        <div className="logoCircle">
-          <img src={logo} alt="logo" width="40" />
-        </div>
-        <h2 className="title">{t('register.titleLeft')}</h2>
-        <p className="desc">{t('register.descLeft')}</p>
-      </div>
-      <div className="register-rightPanel">
+    <div className="dashboard-bg">
+      <Header />
+      <main id="main-content">
+        <div className="register-container">
+          <div className="register-leftPanel">
+            <div className="logoCircle">
+              <img src={logo} alt="logo" width="40" />
+            </div>
+            <h2 className="title">{t('register.titleLeft')}</h2>
+            <p className="desc">{t('register.descLeft')}</p>
+          </div>
+          <div className="register-rightPanel">
         <h2 className="registerTitle">{t('register.title')}</h2>
         <p className="registerDesc">{t('register.desc')}</p>
         <form className="form" onSubmit={handleSubmit} aria-label={t('register.title')}>
@@ -143,6 +147,8 @@ export default function Register() {
           <Link className="registerLink" to="/login">{t('register.login')}</Link>
         </p>
       </div>
+        </div>
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `Header` component to login and register pages
- wrap login and register layouts with `dashboard-bg` and `main` so header stays on top

## Testing
- `npm install --legacy-peer-deps`
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_687590679454832b9a189842c76d2158