### PR TITLE
Fix extra top margin in dashboard

### DIFF
--- a/frontend/src/DashboardAmbiente.css
+++ b/frontend/src/DashboardAmbiente.css
@@ -2,7 +2,7 @@
   font-family: 'Segoe UI', Arial, sans-serif;
   color: #212121;
   background: #f6faff;
-  padding: 30px 0 70px 0;
+  padding: 0 0 70px 0;
   width: 100%;
 }
 


### PR DESCRIPTION
## Summary
- remove extra padding at top of the main dashboard container

## Testing
- `npm test --prefix frontend --silent`

------
https://chatgpt.com/codex/tasks/task_e_68759d989d04832b8e01c18e923bff9b