### PR TITLE
Add query type selector in dashboard

### DIFF
--- a/frontend/src/components/Dashboard.js
+++ b/frontend/src/components/Dashboard.js
@@ -8,6 +8,7 @@ import { mockWeather } from '../data/mockWeather';
 
 export default function Dashboard() {
   const { weather, loading, error, search, city, setCity } = useWeather();
+  const [queryType, setQueryType] = React.useState('Datos Completos');
 
   const aqi = weather.air.uaqi || weather.air.aqi || '-';
   const aqiCategory = weather.air.uaqiCategory || 'Moderado';
@@ -47,8 +48,9 @@ export default function Dashboard() {
             value={city}
             onChange={(e) => setCity(e.target.value)}
           />
-          <select>
+          <select value={queryType} onChange={(e) => setQueryType(e.target.value)}>
             <option>Datos Completos</option>
+            <option>Aire</option>
           </select>
           <button className="consulta-btn" onClick={handleSubmit}>
             Consultar Ahora


### PR DESCRIPTION
## Summary
- add `queryType` state in Dashboard to track filter
- allow selecting between "Datos Completos" and "Aire"

## Testing
- `npm test --silent --runInBand --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68767bd78b40832bbc2e7b6fa2cf30b4