### PR TITLE
Add login and register confirmation button

### DIFF
--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -18,6 +18,7 @@ export default function Login() {
   const [passError, setPassError] = useState("");
   const [showPass, setShowPass] = useState(false);
   const [remember, setRemember] = useState(false);
+  const [success, setSuccess] = useState(false);
   const navigate = useNavigate();
   const { supabase } = useAuth();
   const status = useSupabaseStatus();
@@ -57,7 +58,7 @@ export default function Login() {
         localStorage.removeItem('remember_user');
       }
       setMessage(t('login.success'));
-      navigate("/dashboard");
+      setSuccess(true);
     } else {
       setMessage(t('login.error'));
     }
@@ -139,6 +140,16 @@ export default function Login() {
         {loading && <div className="loader" role="status" aria-label="Cargando"></div>}
         {message && (
           <div className="status-message" aria-live="polite">{message}</div>
+        )}
+        {success && (
+          <button
+            type="button"
+            className="loginBtn"
+            style={{ marginTop: 8 }}
+            onClick={() => navigate('/dashboard')}
+          >
+            {t('login.continue')}
+          </button>
         )}
         {status === 'error' && (
           <div className="status-message" style={{ color: 'red' }} aria-live="polite">

--- a/frontend/src/components/Register.jsx
+++ b/frontend/src/components/Register.jsx
@@ -18,6 +18,7 @@ export default function Register() {
   const [passError, setPassError] = useState('');
   const [showPass, setShowPass] = useState(false);
   const [strength, setStrength] = useState(0);
+  const [success, setSuccess] = useState(false);
   const strengthText = t('register.strength', { returnObjects: true });
   const navigate = useNavigate();
   const { supabase } = useAuth();
@@ -53,7 +54,7 @@ export default function Register() {
     if (!error && data.user) {
       await supabase.from('users').insert({ id: data.user.id, email });
       setMessage(t('register.success'));
-      navigate('/dashboard');
+      setSuccess(true);
     } else {
       setMessage(t('register.error'));
     }
@@ -136,6 +137,16 @@ export default function Register() {
         {loading && <div className="loader" role="status" aria-label="Cargando"></div>}
         {message && (
           <div className="status-message" aria-live="polite">{message}</div>
+        )}
+        {success && (
+          <button
+            type="button"
+            className="registerBtn"
+            style={{ marginTop: 8 }}
+            onClick={() => navigate('/dashboard')}
+          >
+            {t('register.continue')}
+          </button>
         )}
         {status === 'error' && (
           <div className="status-message" style={{ color: 'red' }} aria-live="polite">

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -48,6 +48,7 @@
     "noAccount": "Don't have an account?",
     "register": "Register",
     "remember": "Remember me"
+    , "continue": "Go to dashboard"
   },
   "register": {
     "titleLeft": "Create your account",
@@ -63,6 +64,7 @@
     "error": "Error registering",
     "haveAccount": "Already have an account?",
     "login": "Sign in"
+    , "continue": "Go to dashboard"
   },
   "contact": {
     "title": "Contact",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -48,6 +48,7 @@
     "noAccount": "¿No tienes cuenta?",
     "register": "Regístrate",
     "remember": "Recordar usuario"
+    , "continue": "Ir al dashboard"
   },
   "register": {
     "titleLeft": "Crea tu cuenta",
@@ -63,6 +64,7 @@
     "error": "Error al registrarse",
     "haveAccount": "¿Ya tienes cuenta?",
     "login": "Ingresa"
+    , "continue": "Ir al dashboard"
   },
   "contact": {
     "title": "Contacto",


### PR DESCRIPTION
## Summary
- show success confirmation before navigating on login
- show success confirmation before navigating on registration
- add translations for continue button

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68767ba6918c832b862c3b3a5dbe9579