### PR TITLE
Implement export action

### DIFF
--- a/frontend/src/components/Extras.jsx
+++ b/frontend/src/components/Extras.jsx
@@ -41,6 +41,19 @@ export default function Extras() {
     search(city);
   };
 
+  const handleExport = () => {
+    const rows = data.map((d) => `${d.time},${d.temp},${d.humidity},${d.wind}`);
+    const csv = ['time,temp,humidity,wind', ...rows].join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', 'extras.csv');
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
   const data = trend.length ? trend : mockTrend;
 
   return (
@@ -58,7 +71,7 @@ export default function Extras() {
               required
             />
             <button type="submit" className="aq-btn-aplicar">Aplicar</button>
-            <button type="button" className="aq-btn-exportar">Exportar</button>
+            <button type="button" className="aq-btn-exportar" onClick={handleExport}>Exportar</button>
           </form>
           {loading && <p>Consultando...</p>}
           {error && <p style={{ color: 'red' }}>{error}</p>}

--- a/frontend/src/components/Profile.jsx
+++ b/frontend/src/components/Profile.jsx
@@ -46,6 +46,7 @@ export default function Profile() {
     <div className="dashboard-bg">
       <Header />
       <div className="dashboard-container" aria-labelledby="profile-title">
+        <h2 id="profile-title" className="visually-hidden">Perfil de Usuario</h2>
         <div className="user-card">
           <div className="user-avatar">{initials}</div>
           <div className="user-info">


### PR DESCRIPTION
## Summary
- implement CSV export for extra conditions
- restore "Perfil de Usuario" heading for Profile page

## Testing
- `npm install --force --prefix frontend`
- `CI=true npm test --silent --runInBand --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68767c8c9ae0832ba18cc58546d1e053