### PR TITLE
Add filters to Extras page

### DIFF
--- a/frontend/src/components/ExtrasChart.jsx
+++ b/frontend/src/components/ExtrasChart.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 
-export default function ExtrasChart({ data }) {
+export default function ExtrasChart({ data, metric = 'Todos' }) {
+  const showTemp = metric === 'Todos' || metric === 'Temperatura';
+  const showHumidity = metric === 'Todos' || metric === 'Humedad';
+  const showWind = metric === 'Todos' || metric === 'Viento';
+
   return (
     <ResponsiveContainer width="100%" height={180}>
       <LineChart data={data} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
@@ -10,9 +14,20 @@ export default function ExtrasChart({ data }) {
         <YAxis />
         <Tooltip />
         <Legend />
-        <Line type="monotone" dataKey="temp" stroke="#ff7f0e" name="Temp. °C" />
-        <Line type="monotone" dataKey="humidity" stroke="#1f77b4" name="Humedad %" />
-        <Line type="monotone" dataKey="wind" stroke="#2ca02c" name="Viento m/s" />
+        {showTemp && (
+          <Line type="monotone" dataKey="temp" stroke="#ff7f0e" name="Temp. °C" />
+        )}
+        {showHumidity && (
+          <Line
+            type="monotone"
+            dataKey="humidity"
+            stroke="#1f77b4"
+            name="Humedad %"
+          />
+        )}
+        {showWind && (
+          <Line type="monotone" dataKey="wind" stroke="#2ca02c" name="Viento m/s" />
+        )}
       </LineChart>
     </ResponsiveContainer>
   );


### PR DESCRIPTION
## Summary
- add metric and range filters to Extras page
- support filtering lines in ExtrasChart

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687680ccfb6c832b82f1f1ffc9247e67