### PR TITLE
Fix header layout on mobile

### DIFF
--- a/frontend/src/Landing.css
+++ b/frontend/src/Landing.css
@@ -224,25 +224,28 @@
 
 @media (max-width: 600px) {
   .header {
-    flex-direction: column;
-    gap: 12px;
-    padding: 18px;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 12px;
   }
   .navbar-links {
     justify-content: center;
+    flex-wrap: nowrap;
   }
 }
 .navbar-links {
   display: flex;
   gap: 16px;
   align-items: center;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
 }
 .navbar-links a {
   color: #fff;
   text-decoration: none;
   font-weight: 500;
   padding: 6px 16px;
+  font-size: 0.9rem;
   border-radius: 8px;
   background: #3a4d7a;
 }

--- a/frontend/src/SearchSections.css
+++ b/frontend/src/SearchSections.css
@@ -19,6 +19,14 @@
   border-radius: 8px;
   cursor: pointer;
 }
+
+@media (max-width: 600px) {
+  .section-search input,
+  .section-search button {
+    font-size: 0.85rem;
+    padding: 4px 8px;
+  }
+}
 .section-results {
   position: absolute;
   top: 110%;


### PR DESCRIPTION
## Summary
- keep dashboard header in one row on small screens
- prevent nav links from wrapping
- shrink navbar link and search box font sizes for mobile

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68768407efc0832bb9e958704f161afd