### PR TITLE
Add clear buttons to all filter forms

### DIFF
--- a/frontend/src/AdminPanel.css
+++ b/frontend/src/AdminPanel.css
@@ -21,6 +21,11 @@
   cursor: pointer;
   font-size: 1rem;
 }
+.admin-search .admin-clear {
+  background: #fff;
+  color: #365ab6;
+  border: 1px solid #365ab6;
+}
 .admin-table {
   width: 100%;
   border-collapse: collapse;

--- a/frontend/src/DashboardAmbiente.css
+++ b/frontend/src/DashboardAmbiente.css
@@ -60,6 +60,14 @@
   transition: background .2s;
 }
 .consulta-btn:hover { background: #0e9e65; }
+.consulta-limpiar {
+  background: #fff;
+  color: #13c783;
+  border: 1px solid #13c783;
+  border-radius: 8px;
+  padding: 9px 22px;
+  cursor: pointer;
+}
 
 .condiciones-climaticas {
   background: #fff;

--- a/frontend/src/SearchSections.css
+++ b/frontend/src/SearchSections.css
@@ -19,6 +19,11 @@
   border-radius: 8px;
   cursor: pointer;
 }
+.section-search .clear-btn {
+  background: #fff;
+  color: #2563eb;
+  border: 1px solid #2563eb;
+}
 .section-results {
   position: absolute;
   top: 110%;

--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -62,6 +62,11 @@ export default function AdminPanel() {
     setModal('delete');
   };
 
+  const handleClear = () => {
+    setFilter('');
+    fetchRecords('');
+  };
+
   const closeModal = () => {
     setModal(null);
     setForm({ id: null, email: '' });
@@ -102,15 +107,18 @@ export default function AdminPanel() {
           <h2 id="admin-title" className="search-box-title">Panel de Administración</h2>
           <div className="admin-search">
             <label htmlFor="search-email" className="visually-hidden">Buscar usuario</label>
-            <input
-              id="search-email"
-              type="text"
-              placeholder="Buscar por email"
-              value={filter}
-              onChange={handleSearch}
-            />
-            <button type="button" onClick={openCreate}>Nuevo</button>
-          </div>
+          <input
+            id="search-email"
+            type="text"
+            placeholder="Buscar por email"
+            value={filter}
+            onChange={handleSearch}
+          />
+          <button type="button" className="admin-clear" onClick={handleClear}>
+            Limpiar
+          </button>
+          <button type="button" onClick={openCreate}>Nuevo</button>
+        </div>
           {loading && <p>Cargando...</p>}
           {error && <p style={{ color: 'red' }}>{error}</p>}
           {!loading && (

--- a/frontend/src/components/AirQuality.jsx
+++ b/frontend/src/components/AirQuality.jsx
@@ -59,6 +59,12 @@ export default function AirQuality() {
     URL.revokeObjectURL(url);
   };
 
+  const handleClear = () => {
+    setCity('');
+    setPollutant('PM2.5');
+    setRange('24h');
+  };
+
   return (
     <div className="aq-dashboard-container">
       <Header />
@@ -87,6 +93,7 @@ export default function AirQuality() {
               <option value="1y">Último año</option>
             </select>
             <button type="submit" className="aq-btn-aplicar">Aplicar</button>
+            <button type="button" className="aq-btn-limpiar" onClick={handleClear}>Limpiar</button>
             <button type="button" className="aq-btn-exportar" onClick={handleExport}>Exportar</button>
           </form>
           {loading && <p>Consultando...</p>}

--- a/frontend/src/components/AirQualityDashboard.css
+++ b/frontend/src/components/AirQualityDashboard.css
@@ -97,6 +97,14 @@
   padding: 6px 18px;
   cursor: pointer;
 }
+.aq-btn-limpiar {
+  background: #fff;
+  color: #467eea;
+  border: 1px solid #467eea;
+  border-radius: 6px;
+  padding: 6px 18px;
+  cursor: pointer;
+}
 
 .aq-btn-exportar {
   margin-left: auto;

--- a/frontend/src/components/AirQualityDashboard.jsx
+++ b/frontend/src/components/AirQualityDashboard.jsx
@@ -59,6 +59,12 @@ export default function AirQualityDashboard() {
     URL.revokeObjectURL(url);
   };
 
+  const handleClear = () => {
+    setCity('');
+    setPollutant('PM2.5');
+    setRange('24h');
+  };
+
   return (
     <div className="aq-dashboard-container">
       <header className="aq-header">
@@ -102,6 +108,7 @@ export default function AirQualityDashboard() {
               <option value="1y">Último año</option>
             </select>
             <button type="submit" className="aq-btn-aplicar">Aplicar</button>
+            <button type="button" className="aq-btn-limpiar" onClick={handleClear}>Limpiar</button>
             <button type="button" className="aq-btn-exportar" onClick={handleExport}>Exportar</button>
           </form>
           {loading && <p>Consultando...</p>}

--- a/frontend/src/components/Dashboard.js
+++ b/frontend/src/components/Dashboard.js
@@ -18,6 +18,11 @@ export default function Dashboard() {
     search(city);
   };
 
+  const handleClear = () => {
+    setCity('');
+    setQueryType('Datos Completos');
+  };
+
   const lastUpdate = new Date().toLocaleTimeString('es-ES', {
     hour: '2-digit',
     minute: '2-digit',
@@ -54,6 +59,9 @@ export default function Dashboard() {
           </select>
           <button className="consulta-btn" onClick={handleSubmit}>
             Consultar Ahora
+          </button>
+          <button className="consulta-limpiar" type="button" onClick={handleClear}>
+            Limpiar
           </button>
         </div>
         {loading && <p>Consultando...</p>}

--- a/frontend/src/components/Extras.jsx
+++ b/frontend/src/components/Extras.jsx
@@ -75,6 +75,12 @@ export default function Extras() {
     document.body.removeChild(link);
   };
 
+  const handleClear = () => {
+    setCity('');
+    setMetric('Todos');
+    setRange('24h');
+  };
+
   const baseData = trend.length ? trend : mockTrend;
   const data = useMemo(() => expandTrend(baseData, range), [baseData, range]);
 
@@ -105,6 +111,7 @@ export default function Extras() {
             <option value="1y">Último año</option>
           </select>
           <button type="submit" className="aq-btn-aplicar">Aplicar</button>
+          <button type="button" className="aq-btn-limpiar" onClick={handleClear}>Limpiar</button>
           <button type="button" className="aq-btn-exportar" onClick={handleExport}>Exportar</button>
           </form>
           {loading && <p>Consultando...</p>}

--- a/frontend/src/components/SearchSections.jsx
+++ b/frontend/src/components/SearchSections.jsx
@@ -27,6 +27,10 @@ export default function SearchSections() {
     if (results.length) navigate(results[0].path);
   };
 
+  const handleClear = () => {
+    setQuery('');
+  };
+
   return (
     <form className="section-search" onSubmit={handleSubmit} role="search">
       <input
@@ -37,6 +41,7 @@ export default function SearchSections() {
         aria-label={t('searchPlaceholder')}
       />
       <button type="submit">Go</button>
+      <button type="button" className="clear-btn" onClick={handleClear}>Limpiar</button>
       {query && (
         <ul className="section-results">
           {results.map((r) => (

--- a/frontend/src/components/StatisticsModule.css
+++ b/frontend/src/components/StatisticsModule.css
@@ -39,6 +39,14 @@
   border-radius: 4px;
   cursor: pointer;
 }
+.btn-clear {
+  background: #fff;
+  color: #6f42c1;
+  border: 1px solid #6f42c1;
+  border-radius: 4px;
+  padding: 8px 16px;
+  cursor: pointer;
+}
 
 .btn-export {
   margin-left: auto;

--- a/frontend/src/components/StatisticsModule.jsx
+++ b/frontend/src/components/StatisticsModule.jsx
@@ -52,6 +52,12 @@ export default function StatisticsModule() {
     alert('Reporte exportado con éxito');
   };
 
+  const handleClear = () => {
+    setLocation('');
+    setParameter('temp');
+    setChartType('line');
+  };
+
   const renderChart = () => {
     switch (chartType) {
       case 'bar':
@@ -111,6 +117,9 @@ export default function StatisticsModule() {
           </select>
           <button className="btn-generate" onClick={handleGenerate}>
             Generar
+          </button>
+          <button className="btn-clear" type="button" onClick={handleClear}>
+            Limpiar
           </button>
           <button className="btn-export" onClick={handleExport}>
             <FaDownload /> Exportar Reporte


### PR DESCRIPTION
## Summary
- add a `Limpiar` button in Admin panel search
- add clear button to AirQuality and Extras filter forms
- enable clearing filters on the AirQuality dashboard
- add clear button for dashboard custom query
- allow clearing quick search sections
- support clearing filters in statistics module
- style new buttons in related CSS files

## Testing
- `npm test --silent --runTestsByPath src/App.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6876851af454832b9961f3e7a8cac138