### PR TITLE
Adjust layout for consistency

### DIFF
--- a/frontend/src/Dashboard.css
+++ b/frontend/src/Dashboard.css
@@ -58,8 +58,8 @@ body, .dashboard-bg {
   border-radius: 12px;
   padding: 30px 36px;
   min-width: 600px;
-  max-width: 800px;
-  width: 80%;
+  max-width: 1250px;
+  width: 90%;
   box-shadow: 0 1px 6px #c0d4ec22;
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -68,6 +68,17 @@ export default function Header() {
         >
           {t('header.contact')}
         </NavLink>
+        {isAdmin && (
+          <NavLink
+            to="/admin"
+            style={{ marginLeft: 8 }}
+            className={({ isActive }) => (isActive ? 'active' : '')}
+            >
+              {t('header.admin')}
+            </NavLink>
+          )}
+          </nav>
+          <SearchSections />
           {user ? (
             <NavLink
               to="/profile"
@@ -85,17 +96,6 @@ export default function Header() {
               <div className="profile-circle"></div>
             </NavLink>
           )}
-          {isAdmin && (
-            <NavLink
-              to="/admin"
-              style={{ marginLeft: 8 }}
-              className={({ isActive }) => (isActive ? 'active' : '')}
-            >
-              {t('header.admin')}
-            </NavLink>
-          )}
-          </nav>
-          <SearchSections />
         </div>
       </header>
     </>

--- a/frontend/src/components/InteractiveMapDashboard.css
+++ b/frontend/src/components/InteractiveMapDashboard.css
@@ -53,10 +53,10 @@
 
 .imd-main-content {
   display: flex;
-  max-width: 1400px;
+  max-width: 1250px;
   margin: 30px auto 0 auto;
   background: #fff;
-  border-radius: 18px;
+  border-radius: 16px;
   box-shadow: 0 6px 20px #0001;
   min-height: 720px;
   padding: 0;

--- a/frontend/src/components/StatisticsModule.css
+++ b/frontend/src/components/StatisticsModule.css
@@ -1,8 +1,12 @@
 .stats-module {
   font-family: 'Segoe UI', sans-serif;
   padding: 24px;
-  background: #f6faff;
+  background: #fff;
   color: #333;
+  max-width: 1250px;
+  margin: 24px auto;
+  border-radius: 16px;
+  box-shadow: 0 6px 20px #0001;
 }
 
 .stats-header {


### PR DESCRIPTION
## Summary
- move profile icon to far right of the header
- standardize dashboard widths

## Testing
- `CI=true npm test --silent --runInBand --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876888226e0832b8511e526d1d50d65