### PR TITLE
Fix uniform nav button heights

### DIFF
--- a/frontend/src/Dashboard.css
+++ b/frontend/src/Dashboard.css
@@ -37,6 +37,8 @@ body, .dashboard-bg {
   padding-bottom: 2px;
   outline: none;
   transition: background 0.18s;
+  /* Prevent wrapping so all buttons keep a consistent height */
+  white-space: nowrap;
 }
 .navbar-links a:hover,
 .navbar-links a:focus {

--- a/frontend/src/Landing.css
+++ b/frontend/src/Landing.css
@@ -248,6 +248,8 @@
   font-size: 0.9rem;
   border-radius: 8px;
   background: #3a4d7a;
+  /* Keep text on one line so all buttons remain the same height */
+  white-space: nowrap;
 }
 .navbar-links a:hover {
   background: #2c3a5c;


### PR DESCRIPTION
## Summary
- prevent navigation labels from wrapping

## Testing
- `npm install --force --prefix frontend`
- `CI=true npm test --silent --runInBand --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68768f885bbc832b9dab63e64bced018