### PR TITLE
Fix search placeholder i18n

### DIFF
--- a/frontend/src/components/SearchSections.jsx
+++ b/frontend/src/components/SearchSections.jsx
@@ -37,8 +37,8 @@ export default function SearchSections() {
         type="text"
         value={query}
         onChange={(e) => setQuery(e.target.value)}
-        placeholder={t('searchPlaceholder')}
-        aria-label={t('searchPlaceholder')}
+        placeholder={t('header.searchPlaceholder')}
+        aria-label={t('header.searchPlaceholder')}
       />
       <button type="submit">Go</button>
       <button type="button" className="clear-btn" onClick={handleClear}>Limpiar</button>


### PR DESCRIPTION
## Summary
- update `SearchSections` to use i18n header placeholder key

## Testing
- `npm install --force --prefix frontend`
- `CI=true npm test --silent --runInBand --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68768fcdb9e4832ba34e588b3d16c656