### PR TITLE
Add password requirement hint

### DIFF
--- a/frontend/src/components/Register.jsx
+++ b/frontend/src/components/Register.jsx
@@ -96,6 +96,7 @@ export default function Register() {
             </div>
           )}
           <label className="label" htmlFor="reg-pass">{t('register.password')}</label>
+          <small className="pass-desc">{t('register.passDesc')}</small>
           <div className="inputIcon">
             <input
               className="input"

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -58,6 +58,7 @@
     "desc": "Fill in your details and start exploring",
     "email": "Email",
     "password": "Password",
+    "passDesc": "At least 8 characters including a number",
     "strength": ["Very weak", "Weak", "Fair", "Good", "Strong"],
     "strengthLabel": "Password strength",
     "create": "Create account",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -58,6 +58,7 @@
     "desc": "Completa tus datos y comienza a explorar",
     "email": "Correo",
     "password": "Contraseña",
+    "passDesc": "Mínimo 8 caracteres y al menos un número",
     "strength": ["Muy débil", "Débil", "Regular", "Buena", "Fuerte"],
     "strengthLabel": "Fortaleza de la contraseña",
     "create": "Crear cuenta",


### PR DESCRIPTION
## Summary
- show a short hint below the password label on the register page
- add translations for password hint in English and Spanish

## Testing
- `npm test --silent --runTestsByPath src/components/Register.jsx src/locales/es/translation.json src/locales/en/translation.json` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68769008e404832b932e2ddfdc0e3f82