### PR TITLE
Add confirmation dialogs to contact forms

### DIFF
--- a/frontend/src/components/ContactoAyuda.jsx
+++ b/frontend/src/components/ContactoAyuda.jsx
@@ -88,6 +88,7 @@ export default function ContactoAyuda() {
             <form
               onSubmit={(e) => {
                 e.preventDefault();
+                if (!window.confirm('¿Enviar el reporte?')) return;
                 setErrorSent(true);
                 e.target.reset();
               }}
@@ -140,6 +141,7 @@ export default function ContactoAyuda() {
             <form
               onSubmit={(e) => {
                 e.preventDefault();
+                if (!window.confirm('¿Enviar la sugerencia?')) return;
                 setSuggestionSent(true);
                 e.target.reset();
               }}
@@ -191,6 +193,7 @@ export default function ContactoAyuda() {
             <form
               onSubmit={(e) => {
                 e.preventDefault();
+                if (!window.confirm('¿Enviar el mensaje?')) return;
                 setDirectSent(true);
                 e.target.reset();
               }}


### PR DESCRIPTION
## Summary
- prompt user before sending contact form submissions

## Testing
- `npm test --prefix frontend --silent`

------
https://chatgpt.com/codex/tasks/task_e_68769283eafc832bbd9346af3b90f1f5