### PR TITLE
Fix contact confirmation messages

### DIFF
--- a/frontend/src/components/ContactoAyuda.jsx
+++ b/frontend/src/components/ContactoAyuda.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import '../ContactoAyuda.css';
 import Header from './Header';
 
@@ -6,6 +6,25 @@ export default function ContactoAyuda() {
   const [errorSent, setErrorSent] = useState(false);
   const [suggestionSent, setSuggestionSent] = useState(false);
   const [directSent, setDirectSent] = useState(false);
+
+  // Hide confirmation messages automatically after a few seconds
+  useEffect(() => {
+    if (!errorSent) return;
+    const t = setTimeout(() => setErrorSent(false), 3000);
+    return () => clearTimeout(t);
+  }, [errorSent]);
+
+  useEffect(() => {
+    if (!suggestionSent) return;
+    const t = setTimeout(() => setSuggestionSent(false), 3000);
+    return () => clearTimeout(t);
+  }, [suggestionSent]);
+
+  useEffect(() => {
+    if (!directSent) return;
+    const t = setTimeout(() => setDirectSent(false), 3000);
+    return () => clearTimeout(t);
+  }, [directSent]);
   return (
     <div className="dashboard-bg">
       <Header />


### PR DESCRIPTION
## Summary
- keep contact forms open but show confirmation briefly

## Testing
- `npm test --silent --runInBand --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6876956ccae0832b9e104b3c7ee450e2