### PR TITLE
Add edit and delete options for search history

### DIFF
--- a/frontend/src/Profile.test.js
+++ b/frontend/src/Profile.test.js
@@ -3,7 +3,11 @@ import { MemoryRouter } from 'react-router-dom';
 import Profile from './components/Profile';
 
 jest.mock('./hooks/useWeather', () => ({
-  useWeather: () => ({ history: ['Manta', 'Quito'] })
+  useWeather: () => ({
+    history: ['Manta', 'Quito'],
+    editHistoryEntry: jest.fn(),
+    deleteHistoryEntry: jest.fn(),
+  })
 }));
 
 jest.mock('./AuthContext', () => ({
@@ -66,4 +70,14 @@ test('shows edit profile button', () => {
     </MemoryRouter>
   );
   expect(screen.getByText(/Editar perfil/i)).toBeInTheDocument();
+});
+
+test('shows edit and delete buttons for history', () => {
+  render(
+    <MemoryRouter>
+      <Profile />
+    </MemoryRouter>
+  );
+  expect(screen.getAllByLabelText(/Editar búsqueda/i).length).toBeGreaterThan(0);
+  expect(screen.getAllByLabelText(/Eliminar búsqueda/i).length).toBeGreaterThan(0);
 });

--- a/frontend/src/components/Profile.jsx
+++ b/frontend/src/components/Profile.jsx
@@ -9,7 +9,7 @@ import { useWeather } from '../hooks/useWeather';
 export default function Profile() {
   const { user, supabase } = useAuth();
   const [dark, setDark] = useState(() => localStorage.getItem('pref_dark') === '1');
-  const { history } = useWeather();
+  const { history, editHistoryEntry, deleteHistoryEntry } = useWeather();
   const [showEdit, setShowEdit] = useState(false);
   const [filter, setFilter] = useState('');
   const activityHistory = [
@@ -51,6 +51,19 @@ export default function Profile() {
     .join("")
     .slice(0, 2)
     .toUpperCase();
+
+  const handleEdit = (idx) => {
+    const newValue = prompt('Editar búsqueda', history[idx]);
+    if (newValue) {
+      editHistoryEntry(idx, newValue);
+    }
+  };
+
+  const handleDelete = (idx) => {
+    if (window.confirm('¿Eliminar esta búsqueda?')) {
+      deleteHistoryEntry(idx);
+    }
+  };
 
   return (
     <div className="dashboard-bg">
@@ -112,6 +125,22 @@ export default function Profile() {
                   <div className="history-title-row">
                     <span className="history-title">{c}</span>
                   </div>
+                </div>
+                <div className="history-card-actions">
+                  <button
+                    className="profile-btn edit"
+                    onClick={() => handleEdit(idx)}
+                    aria-label="Editar búsqueda"
+                  >
+                    ✎
+                  </button>
+                  <button
+                    className="profile-btn logout"
+                    onClick={() => handleDelete(idx)}
+                    aria-label="Eliminar búsqueda"
+                  >
+                    🗑
+                  </button>
                 </div>
               </div>
             ))}

--- a/frontend/src/hooks/useWeather.js
+++ b/frontend/src/hooks/useWeather.js
@@ -55,6 +55,23 @@ export function WeatherProvider({ children }) {
     }
   });
 
+  const editHistoryEntry = (index, newValue) => {
+    setHistory((h) => {
+      const updated = [...h];
+      updated[index] = newValue;
+      localStorage.setItem('weather_history', JSON.stringify(updated));
+      return updated;
+    });
+  };
+
+  const deleteHistoryEntry = (index) => {
+    setHistory((h) => {
+      const updated = h.filter((_, i) => i !== index);
+      localStorage.setItem('weather_history', JSON.stringify(updated));
+      return updated;
+    });
+  };
+
   const search = async (newCity) => {
     const cityToSearch = newCity ?? city;
     if (!cityToSearch) return;
@@ -167,7 +184,19 @@ export function WeatherProvider({ children }) {
 
   return (
     <WeatherContext.Provider
-      value={{ weather: data, trend, airTrend, loading, error, search, city, setCity, history }}
+      value={{
+        weather: data,
+        trend,
+        airTrend,
+        loading,
+        error,
+        search,
+        city,
+        setCity,
+        history,
+        editHistoryEntry,
+        deleteHistoryEntry,
+      }}
     >
       {children}
     </WeatherContext.Provider>


### PR DESCRIPTION
## Summary
- allow editing and deleting items stored in `weather_history`
- expose new functions from the weather context
- update profile page to show edit/delete buttons
- extend profile tests for new actions

## Testing
- `npm install --force --prefix frontend`
- `npm test --silent --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6876aa447010832b84aa38d05e043f51