### PR TITLE
Switch backend to SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # Dashboard Ambiental Costero
 
-Demostración de un sistema de monitoreo ambiental con **React** y **Express**. Utiliza Supabase para almacenar usuarios y datos de ejemplo. El repositorio se organiza en dos carpetas principales: `frontend` y `backend`.
+Demostración de un sistema de monitoreo ambiental con **React** y **Express**. Utiliza **SQLite** para almacenar usuarios y datos de ejemplo. Se mantiene el esquema original para Supabase como referencia. El repositorio se organiza en dos carpetas principales: `frontend` y `backend`.
 
 La interfaz es **responsiva** y dispone de un panel de accesibilidad que ajusta contraste, tamaño de texto y otros efectos de acuerdo con las pautas **WCAG 2.2**. El panel incluye un boton para *restablecer parametros*. Consulta el documento [Usability Checklist](USABILITY_CHECKLIST.md) para ver las practicas aplicadas.
 
 ## Requisitos
 - Node.js 18 o superior
-- Cuenta de Supabase con las claves de proyecto
 - Docker (opcional, para ejecución en contenedores)
 - Clave de API de OpenWeatherMap para obtener datos meteorológicos
 
@@ -29,8 +28,7 @@ La interfaz es **responsiva** y dispone de un panel de accesibilidad que ajusta 
 
 ### Backend
 1. Dentro de `backend` crea un archivo `.env` con:
-   - `SUPABASE_URL`
-   - `SUPABASE_KEY`
+   - `DB_FILE` (opcional, ruta del archivo SQLite)
    - `PORT` (opcional, 4000 por defecto)
 2. Instala las dependencias:
    ```bash
@@ -54,7 +52,7 @@ La interfaz es **responsiva** y dispone de un panel de accesibilidad que ajusta 
    La aplicación quedará disponible en `http://localhost:3000`.
 
 ## Base de datos
-En la carpeta `scripts` encontrarás `supabase_schema.sql` con el script para crear todas las tablas necesarias (usuarios, ciudades, historial de consultas y condiciones climáticas). Ejecútalo en tu proyecto de Supabase antes de usar la aplicación.
+En la carpeta `scripts` encontrarás `sqlite_schema.sql` con el esquema que se usa localmente y `supabase_schema.sql` para la versión en Supabase. Ambos definen las mismas tablas (usuarios, ciudades, historial de consultas y condiciones climáticas).
 Las secciones de Aire, Extras, Mapa, Alertas, Estadísticas y Contacto muestran información detallada obtenida de OpenWeatherMap. La página de Contacto cuenta además con formularios para reportar errores y dejar sugerencias.
 
 ## Rutas principales
@@ -76,7 +74,7 @@ Estas son las rutas disponibles en el frontend. Salvo el inicio, login y registr
 | `/profile` | Perfil y preferencias |
 | `/admin` | Panel de administración (solo usuarios administradores) |
 
-El backend expone además `/status` para comprobar la conexión con Supabase.
+El backend expone además `/status` para comprobar la conexión con la base de datos.
 
 ## Pruebas
 Para ejecutar la suite de tests del frontend utiliza:

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,22 +1,29 @@
 require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
-const { createClient } = require('@supabase/supabase-js');
+const sqlite3 = require('sqlite3').verbose();
+const fs = require('fs');
+const path = require('path');
 
 const app = express();
 app.use(cors());
 app.use(express.json());
 
-const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_KEY);
+const dbFile = process.env.DB_FILE || path.join(__dirname, 'database.sqlite');
+const db = new sqlite3.Database(dbFile);
+const schemaPath = path.join(__dirname, '..', 'scripts', 'sqlite_schema.sql');
+const schema = fs.readFileSync(schemaPath, 'utf8');
+db.exec(schema, (err) => {
+  if (err) console.error('Error applying schema', err);
+});
 
-app.get('/status', async (_req, res) => {
-  try {
-    const { error } = await supabase.from('cities').select('id').limit(1);
-    if (error) throw error;
+app.get('/status', (_req, res) => {
+  db.get('SELECT id FROM cities LIMIT 1', (err) => {
+    if (err) {
+      return res.status(500).json({ status: 'error' });
+    }
     res.json({ status: 'ok' });
-  } catch (e) {
-    res.status(500).json({ status: 'error' });
-  }
+  });
 });
 
 const PORT = process.env.PORT || 4000;

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,9 +7,9 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@supabase/supabase-js": "^2.50.0",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "sqlite3": "^5.1.6"
   }
 }

--- a/scripts/sqlite_schema.sql
+++ b/scripts/sqlite_schema.sql
@@ -1,0 +1,62 @@
+-- SQLite version of the database schema. Mirrors Supabase tables.
+CREATE TABLE IF NOT EXISTS users (
+    id TEXT PRIMARY KEY,
+    email TEXT UNIQUE NOT NULL,
+    password_hash TEXT,
+    created_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS cities (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    country TEXT,
+    lat REAL,
+    lon REAL
+);
+
+CREATE TABLE IF NOT EXISTS consults (
+    id TEXT PRIMARY KEY,
+    user_id TEXT REFERENCES users(id),
+    city_id INTEGER REFERENCES cities(id),
+    consulted_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS weather_conditions (
+    id TEXT PRIMARY KEY,
+    consult_id TEXT UNIQUE REFERENCES consults(id),
+    temperatura REAL,
+    humedad REAL,
+    viento REAL,
+    presion_atmosferica REAL
+);
+
+CREATE TABLE IF NOT EXISTS air_quality (
+    id TEXT PRIMARY KEY,
+    consult_id TEXT UNIQUE REFERENCES consults(id),
+    monoxido_de_carbono REAL,
+    dioxido_de_nitrogeno REAL,
+    ozono REAL,
+    particulas_pm25 REAL
+);
+
+CREATE TABLE IF NOT EXISTS additional_conditions (
+    id TEXT PRIMARY KEY,
+    consult_id TEXT UNIQUE REFERENCES consults(id),
+    sensacion_termica REAL,
+    estado_del_cielo TEXT,
+    nubosidad REAL,
+    visibilidad REAL
+);
+
+CREATE TABLE IF NOT EXISTS alerts (
+    id TEXT PRIMARY KEY,
+    consult_id TEXT REFERENCES consults(id),
+    alerta TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_consult_user ON consults(user_id);
+CREATE INDEX IF NOT EXISTS idx_consult_city ON consults(city_id);
+CREATE INDEX IF NOT EXISTS idx_weather_consult ON weather_conditions(consult_id);
+CREATE INDEX IF NOT EXISTS idx_air_consult ON air_quality(consult_id);
+CREATE INDEX IF NOT EXISTS idx_additional_consult ON additional_conditions(consult_id);
+CREATE INDEX IF NOT EXISTS idx_alert_consult ON alerts(consult_id);


### PR DESCRIPTION
## Summary
- use sqlite3 instead of Supabase in the backend
- add SQLite schema script
- document SQLite usage

## Testing
- `npm install --prefix backend`
- `npm install --force --prefix frontend`
- `CI=true npm test --silent --runInBand --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_687ceb1f2e70832b8e9fed68838b0cf8